### PR TITLE
Make price function from price oracle read only

### DIFF
--- a/contracts/DutchExchange.sol
+++ b/contracts/DutchExchange.sol
@@ -167,7 +167,7 @@ contract DutchExchange is DxUpgrade, TokenWhitelist, EthOracle {
         require(token2Funding < 10 ** 30, "You should use a smaller funding for token 2");
 
         uint fundedValueUSD;
-        uint ethUSDPrice = ethUSDOracle.getUSDETHPrice();
+        uint ethUSDPrice = ethUSDOracle.getUsdEthPrice();
 
         // Compute fundedValueUSD
         address ethTokenMem = ethToken;
@@ -683,7 +683,7 @@ contract DutchExchange is DxUpgrade, TokenWhitelist, EthOracle {
         // 10^29 * 10^30 / 10^30 = 10^29
         uint feeInETH = mul(fee, num) / den;
 
-        uint ethUSDPrice = ethUSDOracle.getUSDETHPrice();
+        uint ethUSDPrice = ethUSDOracle.getUsdEthPrice();
         // 10^29 * 10^6 = 10^35
         // Uses 18 decimal places <> exactly as owlToken tokens: 10**18 owlToken == 1 USD
         uint feeInUSD = mul(feeInETH, ethUSDPrice);
@@ -821,7 +821,7 @@ contract DutchExchange is DxUpgrade, TokenWhitelist, EthOracle {
         internal
     {
         // Check if auctions received enough sell orders
-        uint ethUSDPrice = ethUSDOracle.getUSDETHPrice();
+        uint ethUSDPrice = ethUSDOracle.getUsdEthPrice();
 
         uint sellNum;
         uint sellDen;

--- a/src/truffle/add-token-pairs.js
+++ b/src/truffle/add-token-pairs.js
@@ -306,7 +306,7 @@ async function loadContractsInfo () {
 
   // Get ether price from oracle
   const oracle = PriceOracleInterface.at(ethUSDOracleAddress)
-  const etherPrice = await oracle.getUSDETHPrice.call()
+  const etherPrice = await oracle.getUsdEthPrice.call()
 
   // Get the ether balance
   const account = accounts[0]

--- a/test/Tradeflows.js
+++ b/test/Tradeflows.js
@@ -214,7 +214,7 @@ contract('DutchExchange - TradeFlows', accounts => {
       const auctionIndex = await getAuctionIndex()
 
       // general setup information
-      logger('PRICE ORACLE', oracle.getUSDETHPrice.call())
+      logger('PRICE ORACLE', oracle.getUsdEthPrice.call())
 
       // ASSERT Auction has started
       await setAndCheckAuctionStarted(eth, gno)

--- a/test/dutchExchange-addTokenPair.js
+++ b/test/dutchExchange-addTokenPair.js
@@ -3,7 +3,7 @@ const {
   log: utilsLog,
   assertRejects,
   timestamp,
-  gasLogger,
+  gasLogger
 } = require('./utils')
 
 const { getContracts, setupTest } = require('./testFunctions')
@@ -19,20 +19,19 @@ let oracle
 
 let feeRatio
 
-
 let contracts, symbols
 
 const separateLogs = () => utilsLog('\n    ----------------------------------')
 const log = (...args) => utilsLog('\t', ...args)
 
-contract('DutchExchange - addTokenPair', (accounts) => {
+contract('DutchExchange - addTokenPair', accounts => {
   const [master, seller1] = accounts
 
   const startBal = {
     startingETH: 90.0.toWei(),
     startingGNO: 90.0.toWei(),
     ethUSDPrice: 1008.0.toWei(),
-    sellingAmount: 50.0.toWei(),
+    sellingAmount: 50.0.toWei()
   }
 
   let addTokenPairDefaults
@@ -49,7 +48,7 @@ contract('DutchExchange - addTokenPair', (accounts) => {
       TokenGNO: gno,
       TokenFRT: mgn,
       DutchExchange: dx,
-      PriceOracleInterface: oracle,
+      PriceOracleInterface: oracle
     } = contracts)
 
     await setupTest(accounts, contracts, startBal)
@@ -69,21 +68,21 @@ contract('DutchExchange - addTokenPair', (accounts) => {
       token1Funding: 10 ** 6,
       token2Funding: 1000,
       initialClosingPriceNum: 2,
-      initialClosingPriceDen: 1,
+      initialClosingPriceDen: 1
     }
 
     // a new deployed GNO to act as a different token
     gno2 = await TokenGNO.new(1e22, { from: master })
     await Promise.all([
       gno2.transfer(seller1, startBal.startingGNO, { from: master }),
-      gno2.approve(dx.address, startBal.startingGNO, { from: seller1 }),
+      gno2.approve(dx.address, startBal.startingGNO, { from: seller1 })
     ])
     await dx.deposit(gno2.address, startBal.startingGNO, { from: seller1 })
 
     symbols = {
       [eth.address]: 'ETH',
       [gno.address]: 'GNO',
-      [gno2.address]: 'GNO2',
+      [gno2.address]: 'GNO2'
     }
   })
 
@@ -101,14 +100,14 @@ contract('DutchExchange - addTokenPair', (accounts) => {
 
   const getTokenBalances = (account, sellToken, buyToken) => Promise.all([
     getTokenBalance(account, sellToken),
-    getTokenBalance(account, buyToken),
+    getTokenBalance(account, buyToken)
   ])
 
   const assertTokenBalances = (
     [token1Bal, token2Bal],
     balances2,
     token1Funding = addTokenPairDefaults.token1Funding,
-    token2Funding = addTokenPairDefaults.token2Funding,
+    token2Funding = addTokenPairDefaults.token2Funding
   ) => assert.deepEqual(balances2, [token1Bal - token1Funding, token2Bal - token2Funding], 'balances should decrease by tokenFunding amount')
 
   const getAuctionStart = async (sellToken, buyToken) =>
@@ -128,7 +127,7 @@ contract('DutchExchange - addTokenPair', (accounts) => {
   const getAmounts = async (account, sellToken, buyToken) => {
     const [sellerBalance, sellVolumeCurrent] = await Promise.all([
       getSellerBalance(account, sellToken, buyToken, 1),
-      getSellVolumeCurrent(sellToken, buyToken),
+      getSellVolumeCurrent(sellToken, buyToken)
     ])
 
     log(`
@@ -140,14 +139,14 @@ contract('DutchExchange - addTokenPair', (accounts) => {
 
     return {
       sellerBalance,
-      sellVolumeCurrent,
+      sellVolumeCurrent
     }
   }
 
   const getAmountsForPair = async (account, sellToken, buyToken) => {
     const [direct, opposite] = await Promise.all([
       getAmounts(account, sellToken, buyToken),
-      getAmounts(account, buyToken, sellToken),
+      getAmounts(account, buyToken, sellToken)
     ])
 
     return { direct, opposite }
@@ -158,12 +157,12 @@ contract('DutchExchange - addTokenPair', (accounts) => {
   const assertAmounts = (
     { direct, opposite },
     token1Funding = addTokenPairDefaults.token1Funding,
-    token2Funding = addTokenPairDefaults.token2Funding,
+    token2Funding = addTokenPairDefaults.token2Funding
   ) => {
     const token1FundingAfterFee = getAmountAfterFee(token1Funding)
     const token2FundingAfterFee = getAmountAfterFee(token2Funding)
 
-    Object.keys(direct).forEach((key) => {
+    Object.keys(direct).forEach(key => {
       assert.strictEqual(direct[key], token1FundingAfterFee, `${key} should be equal to token1Funding`)
       assert.strictEqual(opposite[key], token2FundingAfterFee, `${key} should be equal to token2Funding`)
     })
@@ -180,7 +179,7 @@ contract('DutchExchange - addTokenPair', (accounts) => {
     assert.deepEqual(
       getEventFromTX(tx, 'NewTokenPair'),
       { sellToken: sellToken.address || sellToken, buyToken: buyToken.address || buyToken },
-      'token pair should be added',
+      'token pair should be added'
     )
 
   const addTokenPair = (account, options) => {
@@ -194,7 +193,7 @@ contract('DutchExchange - addTokenPair', (accounts) => {
       token1Funding,
       token2Funding,
       initialClosingPriceNum,
-      initialClosingPriceDen,
+      initialClosingPriceDen
     } = options
 
     log(`tx params:
@@ -208,7 +207,7 @@ contract('DutchExchange - addTokenPair', (accounts) => {
       token2Funding,
       initialClosingPriceNum,
       initialClosingPriceDen,
-      { from: account },
+      { from: account }
     )
   }
 
@@ -216,9 +215,9 @@ contract('DutchExchange - addTokenPair', (accounts) => {
     sellToken,
     buyToken,
     token1Funding = addTokenPairDefaults.token1Funding,
-    token2Funding = addTokenPairDefaults.token2Funding,
+    token2Funding = addTokenPairDefaults.token2Funding
   ) => {
-    const ETHUSDPrice = await oracle.getUSDETHPrice.call()
+    const ETHUSDPrice = await oracle.getUsdEthPrice.call()
     let fundedValueETH
 
     if (sellToken === eth || sellToken === eth.address) {
@@ -258,7 +257,7 @@ contract('DutchExchange - addTokenPair', (accounts) => {
     sellToken,
     buyToken,
     initialClosingPriceNum = addTokenPairDefaults.initialClosingPriceNum,
-    initialClosingPriceDen = addTokenPairDefaults.initialClosingPriceDen,
+    initialClosingPriceDen = addTokenPairDefaults.initialClosingPriceDen
   ) => {
     const closingPrice1 = await getInitClosingPrice(sellToken, buyToken)
     const closingPrice2 = await getInitClosingPrice(buyToken, sellToken)

--- a/test/dutchExchange-priceOracle.js
+++ b/test/dutchExchange-priceOracle.js
@@ -13,19 +13,18 @@
 const {
   assertRejects, 
   gasLogger,
-  enableContractFlag,
+  enableContractFlag
 } = require('./utils')
 
 const {
   getContracts,
   setupTest,
-  wait,
+  wait
 } = require('./testFunctions')
 
 const Medianizer = artifacts.require('Medianizer')
 const PriceFeed = artifacts.require('PriceFeed')
 const PriceOracleInterface = artifacts.require('PriceOracleInterface')
-
 
 // Test VARS
 let oracle
@@ -41,18 +40,18 @@ const setupContracts = async () => {
   ({
     PriceOracleInterface: oracle,
     PriceFeed: priceFeed,
-    DutchExchange: dx,
+    DutchExchange: dx
   } = contracts)
 }
 
-const c1 = () => contract('DX PriceOracleInterface Flow', (accounts) => {
+const c1 = () => contract('DX PriceOracleInterface Flow', accounts => {
   const [owner, notOwner, newCurator] = accounts
   
   const startBal = {
     startingETH: 1000..toWei(),
     startingGNO: 1000..toWei(),
     ethUSDPrice: 1100..toWei(),   // 400 ETH @ $6000/ETH = $2,400,000 USD
-    sellingAmount: 100..toWei(), // Same as web3.toWei(50, 'ether') - $60,000USD
+    sellingAmount: 100..toWei() // Same as web3.toWei(50, 'ether') - $60,000USD
   }
   
   afterEach(gasLogger)
@@ -68,51 +67,48 @@ const c1 = () => contract('DX PriceOracleInterface Flow', (accounts) => {
     await setupTest(accounts, contracts, startBal)
   })
 
-
   it('raiseEmergency: throws when NON-OWNER tries to call it',
-    async () => assertRejects(oracle.raiseEmergency({ from: notOwner })),
+    async () => assertRejects(oracle.raiseEmergency({ from: notOwner }))
   )
 
   it('raiseEmergency: switches into emergency mode', async () => {
     await oracle.raiseEmergency(true, { from: owner })
     
-    let ethUSDPrice = (await oracle.getUSDETHPrice.call()).toNumber()
+    let ethUSDPrice = (await oracle.getUsdEthPrice.call()).toNumber()
     assert.equal(ethUSDPrice, 600, 'Oracle ethUSDPrice should report emergency price')
     await oracle.raiseEmergency(false, { from: owner })
     
-    ethUSDPrice = (await oracle.getUSDETHPrice.call()).toNumber()
+    ethUSDPrice = (await oracle.getUsdEthPrice.call()).toNumber()
     assert.equal(ethUSDPrice, 1100, 'Oracle ethUSDPrice should on longer report emergency price')
   })
 
-
-
-  it('getUSDETHPrice: calls this correctly', async () => {
-    const ethUSDPrice = (await oracle.getUSDETHPrice.call()).toNumber()
+  it('getUsdEthPrice: calls this correctly', async () => {
+    const ethUSDPrice = (await oracle.getUsdEthPrice.call()).toNumber()
     assert.equal(ethUSDPrice, 1100, 'Oracle ethUSDPrice is not the set price ethUSDPrice: 1100..toWei(),')
   })
 
-  it('getUSDETHPrice: price is correctly restricted if actual price is 0', async () => {   
-    newPriceOracleInterface = await PriceOracleInterface.new(owner, medzr2.address);
+  it('getUsdEthPrice: price is correctly restricted if actual price is 0', async () => {   
+    newPriceOracleInterface = await PriceOracleInterface.new(owner, medzr2.address)
     await dx.initiateEthUsdOracleUpdate(newPriceOracleInterface.address, { from: owner })
-    await assertRejects(dx.updateEthUSDOracle( { from: owner }))
-    await wait(60*60*24*30+5)
-    await dx.updateEthUSDOracle( { from: owner })
-    const ethUSDPrice = (await newPriceOracleInterface.getUSDETHPrice.call()).toNumber()
-    assert.equal(ethUSDPrice, 1, 'Oracle ethUSDPrice is not set and should return 1');
+    await assertRejects(dx.updateEthUSDOracle({ from: owner }))
+    await wait(60 * 60 * 24 * 30 + 5)
+    await dx.updateEthUSDOracle({ from: owner })
+    const ethUSDPrice = (await newPriceOracleInterface.getUsdEthPrice.call()).toNumber()
+    assert.equal(ethUSDPrice, 1, 'Oracle ethUSDPrice is not set and should return 1')
  
  })
-  it('getUSDETHPrice: set price should work correctly', async () => { 
+  it('getUsdEthPrice: set price should work correctly', async () => { 
     const ethUSDPrice = 1500..toWei()
     await Medianizer.at(medzr2.address).set(PriceFeed.address, { from: owner })
     await priceFeed.post(ethUSDPrice, 1516168838 * 2, medzr2.address, { from: owner })
-    const getNewETHUSDPrice = (await newPriceOracleInterface.getUSDETHPrice.call()).toNumber()
+    const getNewETHUSDPrice = (await newPriceOracleInterface.getUsdEthPrice.call()).toNumber()
 
     assert.equal(ethUSDPrice.toEth(), getNewETHUSDPrice, 'Should be same')
   })
 
   it(
     'updateCurator: throws when NON-OWNER tries to change curator',
-    async () => assertRejects(oracle.updateCurator(medzr2, { from: notOwner })),
+    async () => assertRejects(oracle.updateCurator(medzr2, { from: notOwner }))
   )
 
   it('updateCurator: switches OWNER to new OWNER', async () => {
@@ -123,7 +119,6 @@ const c1 = () => contract('DX PriceOracleInterface Flow', (accounts) => {
     assert.notEqual(oldOwner, newOwner, 'Old Owner should NOT == New Owner')
     assert.equal(newCurator, newOwner, 'New Curator passed in is indeed newOwner')
   })
-
 })
 
 enableContractFlag(c1)

--- a/test/dutchExchange-settleFee.js
+++ b/test/dutchExchange-settleFee.js
@@ -31,14 +31,14 @@ const getExchangeParams = async (dxContr = dx) => {
     ethUSDOracle,
     thresholdNewTokenPair,
     thresholdNewAuction] = await Promise.all([
-    dxContr.frtToken.call(),
-    dxContr.owlToken.call(),
-    dxContr.auctioneer.call(),
-    dxContr.ethToken.call(),
-    dxContr.ethUSDOracle.call(),
-    dxContr.thresholdNewTokenPair.call(),
-    dxContr.thresholdNewAuction.call()
-  ])
+      dxContr.frtToken.call(),
+      dxContr.owlToken.call(),
+      dxContr.auctioneer.call(),
+      dxContr.ethToken.call(),
+      dxContr.ethUSDOracle.call(),
+      dxContr.thresholdNewTokenPair.call(),
+      dxContr.thresholdNewAuction.call()
+    ])
 
   return [
     frtToken,
@@ -310,8 +310,8 @@ const c2 = () => contract('DutchExchange - settleFee', accounts => {
 
     //generatae OWL
 
-      gno.approve(owlA.address, 50000 * (10 ** 18))
-      owlA.lockGNO(50000 * (10 ** 18))
+    gno.approve(owlA.address, 50000 * (10 ** 18))
+    owlA.lockGNO(50000 * (10 ** 18))
 
     const depositETH = async (amt, acct) => {
       await eth.deposit({ from: acct, value: amt })
@@ -325,7 +325,7 @@ const c2 = () => contract('DutchExchange - settleFee', accounts => {
     await depositETH(ETHBalance, seller1)
 
 
-    await mgn.updateMinter(dx.address,{from: master})
+    await mgn.updateMinter(dx.address, { from: master })
     /*// add tokenPair ETH GNO
     await dx.addTokenPair(
       eth.address,
@@ -338,7 +338,7 @@ const c2 = () => contract('DutchExchange - settleFee', accounts => {
     )*/
 
     await mgn.updateMinter(master, { from: master })
-    logger('PRICE ORACLE', await oracle.getUSDETHPrice.call())
+    logger('PRICE ORACLE', await oracle.getUsdEthPrice.call())
 
 
     eventWatcher(dx, 'LogNumber')
@@ -481,7 +481,7 @@ const c2 = () => contract('DutchExchange - settleFee', accounts => {
 
   const calculateFeeInUSD = async (fee, token) => {
     const [ETHUSDPrice, [num, den]] = await Promise.all([
-      oracle.getUSDETHPrice.call(),
+      oracle.getUsdEthPrice.call(),
       dx.getPriceOfTokenInLastAuction.call(token),
     ])
 
@@ -605,7 +605,7 @@ const c2 = () => contract('DutchExchange - settleFee', accounts => {
 
     await owl.approve(dx.address, owlAmount * 5, { from: seller1 })
 
-    const amountOfOWLBurned = Math.min( Math.floor(feeInUSD / 2), owlAmount);
+    const amountOfOWLBurned = Math.min(Math.floor(feeInUSD / 2), owlAmount);
     fee = adjustFee(fee, amountOfOWLBurned, feeInUSD)
     assert.isAbove(fee, 0, 'fee must be > 0')
 
@@ -640,12 +640,12 @@ const c2 = () => contract('DutchExchange - settleFee', accounts => {
     const owlAmount = Math.floor(feeInUSD / 2) - 1
 
     const owlBalanceBefore = (await owl.balanceOf(seller1)).toNumber()
-    await owl.transfer(seller1, owlAmount-owlBalanceBefore, { from: master })
+    await owl.transfer(seller1, owlAmount - owlBalanceBefore, { from: master })
     const owlBalance1 = (await owl.balanceOf(seller1)).toNumber()
     assert.strictEqual(owlBalance1, owlAmount, 'account should have OWL balance < feeInUSD / 2')
     assert.isAbove(owlBalance1, 0, 'account should have OWL balance > 0')
 
-    await owl.approve(dx.address, owlAmount*1000, { from: seller1 })
+    await owl.approve(dx.address, owlAmount * 1000, { from: seller1 })
     const amountOfOWLBurned = owlBalance1
 
     fee = adjustFee(fee, amountOfOWLBurned, feeInUSD)

--- a/test/trufflescripts/start_auction.js
+++ b/test/trufflescripts/start_auction.js
@@ -125,7 +125,7 @@ module.exports = async () => {
   // TODO: fails here - dx.updateExchangeParams is not a function
   const { thresholdNewTokenPair } = await getExchangeParams()
 
-  const ETHUSDPrice = (await po.getUSDETHPrice()).toNumber()
+  const ETHUSDPrice = (await po.getUsdEthPrice()).toNumber()
 
   // calculating funded value, depends on oracle price
   let fundedValueUSD


### PR DESCRIPTION
Hey!

This is my current proposal for making the price feed read only.

I just don't emit the event any more, and added the `view` modifier.

I also expose the validity using the `getUsdEthPricePeek` (but I removed the event).

Lastly, I renamed the method to use camelCase convention, but I left also the old method for the time being while we adapt the projects. I'm happy to remove it for good in this PR too, the find and replace can be done easily in all the project :) 


