### PR TITLE
Fix/solium issues

### DIFF
--- a/.soliumrc.json
+++ b/.soliumrc.json
@@ -16,8 +16,8 @@
       "warning",
       5
     ],
-    "error-reason": [
-      "off"
-    ]
+    "error-reason": 0,
+    "security/no-assign-params": 0,
+    "security/no-inline-assembly": 0
   }
 }

--- a/.soliumrc.json
+++ b/.soliumrc.json
@@ -17,7 +17,6 @@
       5
     ],
     "error-reason": 0,
-    "security/no-assign-params": 0,
-    "security/no-inline-assembly": 0
+    "security/no-assign-params": 0
   }
 }

--- a/contracts/DutchExchange.sol
+++ b/contracts/DutchExchange.sol
@@ -11,6 +11,7 @@ import "./base/DxUpgrade.sol";
 /// @author Alex Herrmann - <alex@gnosis.pm>
 /// @author Dominik Teiml - <dominik@gnosis.pm>
 
+
 contract DutchExchange is DxUpgrade, TokenWhitelist, EthOracle {
     // The price is a rational number, so we need a concept of a fraction
     struct fraction {

--- a/contracts/DutchExchange.sol
+++ b/contracts/DutchExchange.sol
@@ -90,8 +90,8 @@ contract DutchExchange is DxUpgrade, TokenWhitelist, EthOracle {
         uint arrayLength;
 
         for (uint k = 0; k < tokens.length - 1; k++) {
-            for (uint l = k + 1; l < tokens.length; l++) {
-                if (getAuctionIndex(tokens[k], tokens[l]) > 0) {
+            for (uint j = k + 1; j < tokens.length; j++) {
+                if (getAuctionIndex(tokens[k], tokens[j]) > 0) {
                     arrayLength++;
                 }
             }

--- a/contracts/DutchExchange.sol
+++ b/contracts/DutchExchange.sol
@@ -13,8 +13,8 @@ import "./base/DxUpgrade.sol";
 
 
 contract DutchExchange is DxUpgrade, TokenWhitelist, EthOracle {
-    // The price is a rational number, so we need a concept of a fraction
-    struct fraction {
+    // The price is a rational number, so we need a concept of a Fraction
+    struct Fraction {
         uint num;
         uint den;
     }
@@ -45,7 +45,7 @@ contract DutchExchange is DxUpgrade, TokenWhitelist, EthOracle {
     mapping(address => mapping(address => uint)) public auctionStarts;
 
     // Token => Token => auctionIndex => price
-    mapping(address => mapping(address => mapping(uint => fraction))) public closingPrices;
+    mapping(address => mapping(address => mapping(uint => Fraction))) public closingPrices;
 
     // Token => Token => amount
     mapping(address => mapping(address => uint)) public sellVolumesCurrent;
@@ -66,6 +66,303 @@ contract DutchExchange is DxUpgrade, TokenWhitelist, EthOracle {
     mapping(address => mapping(address => mapping(uint => mapping(address => uint)))) public buyerBalances;
     mapping(address => mapping(address => mapping(uint => mapping(address => uint)))) public claimedAmounts;
 
+    function depositAndSell(address sellToken, address buyToken, uint amount)
+        external
+        returns (uint newBal, uint auctionIndex, uint newSellerBal)
+    {
+        newBal = deposit(sellToken, amount);
+        (auctionIndex, newSellerBal) = postSellOrder(sellToken, buyToken, 0, amount);
+    }
+
+    function claimAndWithdraw(address sellToken, address buyToken, address user, uint auctionIndex, uint amount)
+        external
+        returns (uint returned, uint frtsIssued, uint newBal)
+    {
+        (returned, frtsIssued) = claimSellerFunds(sellToken, buyToken, user, auctionIndex);
+        newBal = withdraw(buyToken, amount);
+    }
+
+    function getRunningTokenPairs(address[] calldata tokens)
+        external
+        view
+        returns (address[] memory tokens1, address[] memory tokens2)
+    {
+        uint arrayLength;
+
+        for (uint k = 0; k < tokens.length - 1; k++) {
+            for (uint l = k + 1; l < tokens.length; l++) {
+                if (getAuctionIndex(tokens[k], tokens[l]) > 0) {
+                    arrayLength++;
+                }
+            }
+        }
+
+        tokens1 = new address[](arrayLength);
+        tokens2 = new address[](arrayLength);
+
+        uint h;
+
+        for (uint i = 0; i < tokens.length - 1; i++) {
+            for (uint j = i + 1; j < tokens.length; j++) {
+                if (getAuctionIndex(tokens[i], tokens[j]) > 0) {
+                    tokens1[h] = tokens[i];
+                    tokens2[h] = tokens[j];
+                    h++;
+                }
+            }
+        }
+    }
+
+    /// @dev for quick overview of possible sellerBalances to calculate the possible withdraw tokens
+    /// @param auctionSellToken is the sellToken defining an auctionPair
+    /// @param auctionBuyToken is the buyToken defining an auctionPair
+    /// @param user is the user who wants to his tokens
+    /// @param lastNAuctions how many auctions will be checked. 0 means all
+    //@returns returns sellbal for all indices for all tokenpairs
+    function getIndicesWithClaimableTokensForSellers(
+        address auctionSellToken,
+        address auctionBuyToken,
+        address user,
+        uint lastNAuctions
+    ) external view returns (uint[] memory indices, uint[] memory usersBalances)
+    {
+        uint runningAuctionIndex = getAuctionIndex(auctionSellToken, auctionBuyToken);
+
+        uint arrayLength;
+
+        uint startingIndex = lastNAuctions == 0 ? 1 : runningAuctionIndex - lastNAuctions + 1;
+
+        for (uint j = startingIndex; j <= runningAuctionIndex; j++) {
+            if (sellerBalances[auctionSellToken][auctionBuyToken][j][user] > 0) {
+                arrayLength++;
+            }
+        }
+
+        indices = new uint[](arrayLength);
+        usersBalances = new uint[](arrayLength);
+
+        uint k;
+
+        for (uint i = startingIndex; i <= runningAuctionIndex; i++) {
+            if (sellerBalances[auctionSellToken][auctionBuyToken][i][user] > 0) {
+                indices[k] = i;
+                usersBalances[k] = sellerBalances[auctionSellToken][auctionBuyToken][i][user];
+                k++;
+            }
+        }
+    }
+
+    /// @dev for quick overview of current sellerBalances for a user
+    /// @param auctionSellTokens are the sellTokens defining an auctionPair
+    /// @param auctionBuyTokens are the buyTokens defining an auctionPair
+    /// @param user is the user who wants to his tokens
+    function getSellerBalancesOfCurrentAuctions(
+        address[] calldata auctionSellTokens,
+        address[] calldata auctionBuyTokens,
+        address user
+    ) external view returns (uint[] memory)
+    {
+        uint length = auctionSellTokens.length;
+        uint length2 = auctionBuyTokens.length;
+        require(length == length2);
+
+        uint[] memory sellersBalances = new uint[](length);
+
+        for (uint i = 0; i < length; i++) {
+            uint runningAuctionIndex = getAuctionIndex(auctionSellTokens[i], auctionBuyTokens[i]);
+            sellersBalances[i] = sellerBalances[auctionSellTokens[i]][auctionBuyTokens[i]][runningAuctionIndex][user];
+        }
+
+        return sellersBalances;
+    }
+
+    /// @dev for quick overview of possible buyerBalances to calculate the possible withdraw tokens
+    /// @param auctionSellToken is the sellToken defining an auctionPair
+    /// @param auctionBuyToken is the buyToken defining an auctionPair
+    /// @param user is the user who wants to his tokens
+    /// @param lastNAuctions how many auctions will be checked. 0 means all
+    //@returns returns sellbal for all indices for all tokenpairs
+    function getIndicesWithClaimableTokensForBuyers(
+        address auctionSellToken,
+        address auctionBuyToken,
+        address user,
+        uint lastNAuctions
+    ) external view returns (uint[] memory indices, uint[] memory usersBalances)
+    {
+        uint runningAuctionIndex = getAuctionIndex(auctionSellToken, auctionBuyToken);
+
+        uint arrayLength;
+
+        uint startingIndex = lastNAuctions == 0 ? 1 : runningAuctionIndex - lastNAuctions + 1;
+
+        for (uint j = startingIndex; j <= runningAuctionIndex; j++) {
+            if (buyerBalances[auctionSellToken][auctionBuyToken][j][user] > 0) {
+                arrayLength++;
+            }
+        }
+
+        indices = new uint[](arrayLength);
+        usersBalances = new uint[](arrayLength);
+
+        uint k;
+
+        for (uint i = startingIndex; i <= runningAuctionIndex; i++) {
+            if (buyerBalances[auctionSellToken][auctionBuyToken][i][user] > 0) {
+                indices[k] = i;
+                usersBalances[k] = buyerBalances[auctionSellToken][auctionBuyToken][i][user];
+                k++;
+            }
+        }
+    }
+
+    /// @dev for quick overview of current sellerBalances for a user
+    /// @param auctionSellTokens are the sellTokens defining an auctionPair
+    /// @param auctionBuyTokens are the buyTokens defining an auctionPair
+    /// @param user is the user who wants to his tokens
+    function getBuyerBalancesOfCurrentAuctions(
+        address[] calldata auctionSellTokens,
+        address[] calldata auctionBuyTokens,
+        address user
+    ) external view returns (uint[] memory)
+    {
+        uint length = auctionSellTokens.length;
+        uint length2 = auctionBuyTokens.length;
+        require(length == length2);
+
+        uint[] memory buyersBalances = new uint[](length);
+
+        for (uint i = 0; i < length; i++) {
+            uint runningAuctionIndex = getAuctionIndex(auctionSellTokens[i], auctionBuyTokens[i]);
+            buyersBalances[i] = buyerBalances[auctionSellTokens[i]][auctionBuyTokens[i]][runningAuctionIndex][user];
+        }
+
+        return buyersBalances;
+    }
+
+/// @dev for multiple claims
+    /// @param auctionSellTokens are the sellTokens defining an auctionPair
+    /// @param auctionBuyTokens are the buyTokens defining an auctionPair
+    /// @param auctionIndices are the auction indices on which an token should be claimedAmounts
+    /// @param user is the user who wants to his tokens
+    function claimTokensFromSeveralAuctionsAsSeller(
+        address[] calldata auctionSellTokens,
+        address[] calldata auctionBuyTokens,
+        uint[] calldata auctionIndices,
+        address user
+    ) external returns (uint[] memory, uint[] memory)
+    {
+        uint length = checkLengthsForSeveralAuctionClaiming(auctionSellTokens, auctionBuyTokens, auctionIndices);
+
+        uint[] memory claimAmounts = new uint[](length);
+        uint[] memory frtsIssuedList = new uint[](length);
+
+        for (uint i = 0; i < length; i++) {
+            (claimAmounts[i], frtsIssuedList[i]) = claimSellerFunds(
+                auctionSellTokens[i],
+                auctionBuyTokens[i],
+                user,
+                auctionIndices[i]
+            );
+        }
+
+        return (claimAmounts, frtsIssuedList);
+    }
+
+    /// @dev for multiple claims
+    /// @param auctionSellTokens are the sellTokens defining an auctionPair
+    /// @param auctionBuyTokens are the buyTokens defining an auctionPair
+    /// @param auctionIndices are the auction indices on which an token should be claimedAmounts
+    /// @param user is the user who wants to his tokens
+    function claimTokensFromSeveralAuctionsAsBuyer(
+        address[] calldata auctionSellTokens,
+        address[] calldata auctionBuyTokens,
+        uint[] calldata auctionIndices,
+        address user
+    ) external returns (uint[] memory, uint[] memory)
+    {
+        uint length = checkLengthsForSeveralAuctionClaiming(auctionSellTokens, auctionBuyTokens, auctionIndices);
+
+        uint[] memory claimAmounts = new uint[](length);
+        uint[] memory frtsIssuedList = new uint[](length);
+
+        for (uint i = 0; i < length; i++) {
+            (claimAmounts[i], frtsIssuedList[i]) = claimBuyerFunds(
+                auctionSellTokens[i],
+                auctionBuyTokens[i],
+                user,
+                auctionIndices[i]
+            );
+        }
+
+        return (claimAmounts, frtsIssuedList);
+    }
+
+    /// @dev for multiple withdraws
+    /// @param auctionSellTokens are the sellTokens defining an auctionPair
+    /// @param auctionBuyTokens are the buyTokens defining an auctionPair
+    /// @param auctionIndices are the auction indices on which an token should be claimedAmounts
+    function claimAndWithdrawTokensFromSeveralAuctionsAsSeller(
+        address[] calldata auctionSellTokens,
+        address[] calldata auctionBuyTokens,
+        uint[] calldata auctionIndices
+    ) external returns (uint[] memory, uint frtsIssued)
+    {
+        uint length = checkLengthsForSeveralAuctionClaiming(auctionSellTokens, auctionBuyTokens, auctionIndices);
+
+        uint[] memory claimAmounts = new uint[](length);
+        uint claimFrts = 0;
+
+        for (uint i = 0; i < length; i++) {
+            (claimAmounts[i], claimFrts) = claimSellerFunds(
+                auctionSellTokens[i],
+                auctionBuyTokens[i],
+                msg.sender,
+                auctionIndices[i]
+            );
+
+            frtsIssued += claimFrts;
+
+            withdraw(auctionBuyTokens[i], claimAmounts[i]);
+        }
+
+        return (claimAmounts, frtsIssued);
+    }
+
+    /// @dev for multiple withdraws
+    /// @param auctionSellTokens are the sellTokens defining an auctionPair
+    /// @param auctionBuyTokens are the buyTokens defining an auctionPair
+    /// @param auctionIndices are the auction indices on which an token should be claimedAmounts
+    function claimAndWithdrawTokensFromSeveralAuctionsAsBuyer(
+        address[] calldata auctionSellTokens,
+        address[] calldata auctionBuyTokens,
+        uint[] calldata auctionIndices
+    ) external returns (uint[] memory, uint frtsIssued)
+    {
+        uint length = checkLengthsForSeveralAuctionClaiming(auctionSellTokens, auctionBuyTokens, auctionIndices);
+
+        uint[] memory claimAmounts = new uint[](length);
+        uint claimFrts = 0;
+
+        for (uint i = 0; i < length; i++) {
+            (claimAmounts[i], claimFrts) = claimBuyerFunds(
+                auctionSellTokens[i],
+                auctionBuyTokens[i],
+                msg.sender,
+                auctionIndices[i]
+            );
+
+            frtsIssued += claimFrts;
+
+            withdraw(auctionSellTokens[i], claimAmounts[i]);
+        }
+
+        return (claimAmounts, frtsIssued);
+    }
+
+    function getMasterCopy() external view returns (address) {
+        return masterCopy;
+    }
+
     /// @dev Constructor-Function creates exchange
     /// @param _frtToken - address of frtToken ERC-20 token
     /// @param _owlToken - address of owlToken ERC-20 token
@@ -81,7 +378,8 @@ contract DutchExchange is DxUpgrade, TokenWhitelist, EthOracle {
         PriceOracleInterface _ethUSDOracle,
         uint _thresholdNewTokenPair,
         uint _thresholdNewAuction
-    ) public {
+    ) public
+    {
         // Make sure contract hasn't been initialised
         require(ethToken == address(0), "The contract must be uninitialized");
 
@@ -118,7 +416,8 @@ contract DutchExchange is DxUpgrade, TokenWhitelist, EthOracle {
         uint token2Funding,
         uint initialClosingPriceNum,
         uint initialClosingPriceDen
-    ) public {
+    ) public
+    {
         // R1
         require(token1 != token2, "You cannot add a token pair using the same token");
 
@@ -177,64 +476,11 @@ contract DutchExchange is DxUpgrade, TokenWhitelist, EthOracle {
         require(fundedValueUSD >= thresholdNewTokenPair, "You should surplus the threshold for adding token pairs");
 
         // Save prices of opposite auctions
-        closingPrices[token1][token2][0] = fraction(initialClosingPriceNum, initialClosingPriceDen);
-        closingPrices[token2][token1][0] = fraction(initialClosingPriceDen, initialClosingPriceNum);
+        closingPrices[token1][token2][0] = Fraction(initialClosingPriceNum, initialClosingPriceDen);
+        closingPrices[token2][token1][0] = Fraction(initialClosingPriceDen, initialClosingPriceNum);
 
         // Split into two fns because of 16 local-var cap
         addTokenPairSecondPart(token1, token2, token1Funding, token2Funding);
-    }
-
-    function calculateFundedValueTokenToken(
-        address token1,
-        address token2,
-        uint token1Funding,
-        uint token2Funding,
-        address ethTokenMem,
-        uint ethUSDPrice
-    ) internal view returns (uint fundedValueUSD) {
-        // We require there to exist ethToken-Token auctions
-        // R3.1
-        require(getAuctionIndex(token1, ethTokenMem) > 0);
-
-        // R3.2
-        require(getAuctionIndex(token2, ethTokenMem) > 0);
-
-        // Price of Token 1
-        uint priceToken1Num;
-        uint priceToken1Den;
-        (priceToken1Num, priceToken1Den) = getPriceOfTokenInLastAuction(token1);
-
-        // Price of Token 2
-        uint priceToken2Num;
-        uint priceToken2Den;
-        (priceToken2Num, priceToken2Den) = getPriceOfTokenInLastAuction(token2);
-
-        // Compute funded value in ethToken and USD
-        // 10^30 * 10^30 = 10^60
-        uint fundedValueETH = add(
-            mul(token1Funding, priceToken1Num) / priceToken1Den,
-            token2Funding * priceToken2Num / priceToken2Den
-        );
-
-        fundedValueUSD = mul(fundedValueETH, ethUSDPrice);
-    }
-
-    function addTokenPairSecondPart(address token1, address token2, uint token1Funding, uint token2Funding) internal {
-        balances[token1][msg.sender] = sub(balances[token1][msg.sender], token1Funding);
-        balances[token2][msg.sender] = sub(balances[token2][msg.sender], token2Funding);
-
-        // Fee mechanism, fees are added to extraTokens
-        uint token1FundingAfterFee = settleFee(token1, token2, 1, token1Funding);
-        uint token2FundingAfterFee = settleFee(token2, token1, 1, token2Funding);
-
-        // Update other variables
-        sellVolumesCurrent[token1][token2] = token1FundingAfterFee;
-        sellVolumesCurrent[token2][token1] = token2FundingAfterFee;
-        sellerBalances[token1][token2][1][msg.sender] = token1FundingAfterFee;
-        sellerBalances[token2][token1][1][msg.sender] = token2FundingAfterFee;
-
-        setAuctionStart(token1, token2, WAITING_PERIOD_NEW_TOKEN_PAIR);
-        emit NewTokenPair(token1, token2);
     }
 
     function deposit(address tokenAddress, uint amount) public returns (uint) {
@@ -427,7 +673,7 @@ contract DutchExchange is DxUpgrade, TokenWhitelist, EthOracle {
         require(sellerBalance > 0);
 
         // Get closing price for said auction
-        fraction memory closingPrice = closingPrices[sellToken][buyToken][auctionIndex];
+        Fraction memory closingPrice = closingPrices[sellToken][buyToken][auctionIndex];
         uint num = closingPrice.num;
         uint den = closingPrice.den;
 
@@ -438,14 +684,28 @@ contract DutchExchange is DxUpgrade, TokenWhitelist, EthOracle {
         // < 10^30 * 10^30 = 10^60
         returned = mul(sellerBalance, num) / den;
 
-        frtsIssued = issueFrts(sellToken, buyToken, returned, auctionIndex, sellerBalance, user);
+        frtsIssued = issueFrts(
+            sellToken,
+            buyToken,
+            returned,
+            auctionIndex,
+            sellerBalance,
+            user
+        );
 
         // Claim tokens
         sellerBalances[sellToken][buyToken][auctionIndex][user] = 0;
         if (returned > 0) {
             balances[buyToken][user] = add(balances[buyToken][user], returned);
         }
-        emit NewSellerFundsClaim(sellToken, buyToken, user, auctionIndex, returned, frtsIssued);
+        emit NewSellerFundsClaim(
+            sellToken,
+            buyToken,
+            user,
+            auctionIndex,
+            returned,
+            frtsIssued
+        );
     }
 
     function claimBuyerFunds(address sellToken, address buyToken, address user, uint auctionIndex)
@@ -482,7 +742,14 @@ contract DutchExchange is DxUpgrade, TokenWhitelist, EthOracle {
             ) / closingPrices[sellToken][buyToken][auctionIndex].num;
             returned = add(returned, tokensExtra);
 
-            frtsIssued = issueFrts(buyToken, sellToken, mul(buyerBalance, den) / num, auctionIndex, buyerBalance, user);
+            frtsIssued = issueFrts(
+                buyToken,
+                sellToken,
+                mul(buyerBalance, den) / num,
+                auctionIndex,
+                buyerBalance,
+                user
+            );
 
             // Auction has closed
             // Reset buyerBalances and claimedAmounts
@@ -495,36 +762,15 @@ contract DutchExchange is DxUpgrade, TokenWhitelist, EthOracle {
             balances[sellToken][user] = add(balances[sellToken][user], returned);
         }
 
-        emit NewBuyerFundsClaim(sellToken, buyToken, user, auctionIndex, returned, frtsIssued);
-    }
-
-    function issueFrts(address primaryToken, address secondaryToken, uint x, uint auctionIndex, uint bal, address user)
-        internal
-        returns (uint frtsIssued)
-    {
-        if (approvedTokens[primaryToken] && approvedTokens[secondaryToken]) {
-            address ethTokenMem = ethToken;
-            // Get frts issued based on ETH price of returned tokens
-            if (primaryToken == ethTokenMem) {
-                frtsIssued = bal;
-            } else if (secondaryToken == ethTokenMem) {
-                // 10^30 * 10^39 = 10^66
-                frtsIssued = x;
-            } else {
-                // Neither token is ethToken, so we use getHhistoricalPriceOracle()
-                uint pastNum;
-                uint pastDen;
-                (pastNum, pastDen) = getPriceInPastAuction(primaryToken, ethTokenMem, auctionIndex - 1);
-                // 10^30 * 10^35 = 10^65
-                frtsIssued = mul(bal, pastNum) / pastDen;
-            }
-
-            if (frtsIssued > 0) {
-                // Issue frtToken
-                frtToken.mintTokens(user, frtsIssued);
-            }
-        }
-    }
+        emit NewBuyerFundsClaim(
+            sellToken,
+            buyToken,
+            user,
+            auctionIndex,
+            returned,
+            frtsIssued
+        );
+    }    
 
     /// @dev allows to close possible theoretical closed markets
     /// @param sellToken sellToken of an auction
@@ -577,6 +823,281 @@ contract DutchExchange is DxUpgrade, TokenWhitelist, EthOracle {
             unclaimedBuyerFunds = atleastZero(
                 int(mul(buyerBalance, den) / num - claimedAmounts[sellToken][buyToken][auctionIndex][user])
             );
+        }
+    }
+
+    function getFeeRatio(address user)
+        public
+        view
+        returns (
+        // feeRatio < 10^4
+        uint num,
+        uint den
+    )
+    {
+        uint totalSupply = frtToken.totalSupply();
+        uint lockedFrt = frtToken.lockedTokenBalances(user);
+
+        /*
+          Fee Model:
+            locked FRT range     Fee
+            -----------------   ------
+            [0, 0.01%)           0.5%
+            [0.01%, 0.1%)        0.4%
+            [0.1%, 1%)           0.3%
+            [1%, 10%)            0.2%
+            [10%, 100%)          0.1%
+        */
+
+        if (lockedFrt * 10000 < totalSupply || totalSupply == 0) {
+            // Maximum fee, if user has locked less than 0.01% of the total FRT
+            // Fee: 0.5%
+            num = 1;
+            den = 200;
+        } else if (lockedFrt * 1000 < totalSupply) {
+            // If user has locked more than 0.01% and less than 0.1% of the total FRT
+            // Fee: 0.4%
+            num = 1;
+            den = 250;
+        } else if (lockedFrt * 100 < totalSupply) {
+            // If user has locked more than 0.1% and less than 1% of the total FRT
+            // Fee: 0.3%
+            num = 3;
+            den = 1000;
+        } else if (lockedFrt * 10 < totalSupply) {
+            // If user has locked more than 1% and less than 10% of the total FRT
+            // Fee: 0.2%
+            num = 1;
+            den = 500;
+        } else {
+            // If user has locked more than 10% of the total FRT
+            // Fee: 0.1%
+            num = 1;
+            den = 1000;
+        }
+    }
+
+    //@ dev returns price in units [token2]/[token1]
+    //@ param token1 first token for price calculation
+    //@ param token2 second token for price calculation
+    //@ param auctionIndex index for the auction to get the averaged price from
+    function getPriceInPastAuction(address token1, address token2, uint auctionIndex)
+        public
+        view
+        returns (
+        // price < 10^31
+        uint num,
+        uint den
+    )
+    {
+        if (token1 == token2) {
+            // C1
+            num = 1;
+            den = 1;
+        } else {
+            // C2
+            // R2.1
+            require(auctionIndex >= 0);
+
+            // C3
+            // R3.1
+            require(auctionIndex <= getAuctionIndex(token1, token2));
+            // auction still running
+
+            uint i = 0;
+            bool correctPair = false;
+            Fraction memory closingPriceToken1;
+            Fraction memory closingPriceToken2;
+
+            while (!correctPair) {
+                closingPriceToken2 = closingPrices[token2][token1][auctionIndex - i];
+                closingPriceToken1 = closingPrices[token1][token2][auctionIndex - i];
+
+                if (closingPriceToken1.num > 0 && closingPriceToken1.den > 0 || closingPriceToken2.num > 0 && closingPriceToken2.den > 0) {
+                    correctPair = true;
+                }
+                i++;
+            }
+
+            // At this point at least one closing price is strictly positive
+            // If only one is positive, we want to output that
+            if (closingPriceToken1.num == 0 || closingPriceToken1.den == 0) {
+                num = closingPriceToken2.den;
+                den = closingPriceToken2.num;
+            } else if (closingPriceToken2.num == 0 || closingPriceToken2.den == 0) {
+                num = closingPriceToken1.num;
+                den = closingPriceToken1.den;
+            } else {
+                // If both prices are positive, output weighted average
+                num = closingPriceToken2.den + closingPriceToken1.num;
+                den = closingPriceToken2.num + closingPriceToken1.den;
+            }
+        }
+    }
+
+    /// @dev Gives best estimate for market price of a token in ETH of any price oracle on the Ethereum network
+    /// @param token address of ERC-20 token
+    /// @return Weighted average of closing prices of opposite Token-ethToken auctions, based on their sellVolume
+    function getPriceOfTokenInLastAuction(address token)
+        public
+        view
+        returns (
+        // price < 10^31
+        uint num,
+        uint den
+    )
+    {
+        uint latestAuctionIndex = getAuctionIndex(token, ethToken);
+        // getPriceInPastAuction < 10^30
+        (num, den) = getPriceInPastAuction(token, ethToken, latestAuctionIndex - 1);
+    }
+
+    function getCurrentAuctionPrice(address sellToken, address buyToken, uint auctionIndex)
+        public
+        view
+        returns (
+        // price < 10^37
+        uint num,
+        uint den
+    )
+    {
+        Fraction memory closingPrice = closingPrices[sellToken][buyToken][auctionIndex];
+
+        if (closingPrice.den != 0) {
+            // Auction has closed
+            (num, den) = (closingPrice.num, closingPrice.den);
+        } else if (auctionIndex > getAuctionIndex(sellToken, buyToken)) {
+            (num, den) = (0, 0);
+        } else {
+            // Auction is running
+            uint pastNum;
+            uint pastDen;
+            (pastNum, pastDen) = getPriceInPastAuction(sellToken, buyToken, auctionIndex - 1);
+
+            // If we're calling the function into an unstarted auction,
+            // it will return the starting price of that auction
+            uint timeElapsed = atleastZero(int(now - getAuctionStart(sellToken, buyToken)));
+
+            // The numbers below are chosen such that
+            // P(0 hrs) = 2 * lastClosingPrice, P(6 hrs) = lastClosingPrice, P(>=24 hrs) = 0
+
+            // 10^5 * 10^31 = 10^36
+            num = atleastZero(int((86400 - timeElapsed) * pastNum));
+            // 10^6 * 10^31 = 10^37
+            den = mul((timeElapsed + 43200), pastDen);
+
+            if (mul(num, sellVolumesCurrent[sellToken][buyToken]) <= mul(den, buyVolumes[sellToken][buyToken])) {
+                num = buyVolumes[sellToken][buyToken];
+                den = sellVolumesCurrent[sellToken][buyToken];
+            }
+        }
+    }
+
+    // > Helper fns
+    function getTokenOrder(address token1, address token2) public pure returns (address, address) {
+        if (token2 < token1) {
+            (token1, token2) = (token2, token1);
+        }
+
+        return (token1, token2);
+    }
+
+    function getAuctionStart(address token1, address token2) public view returns (uint auctionStart) {
+        (token1, token2) = getTokenOrder(token1, token2);
+        auctionStart = auctionStarts[token1][token2];
+    }
+
+    function getAuctionIndex(address token1, address token2) public view returns (uint auctionIndex) {
+        (token1, token2) = getTokenOrder(token1, token2);
+        auctionIndex = latestAuctionIndices[token1][token2];
+    }
+
+    function calculateFundedValueTokenToken(
+        address token1,
+        address token2,
+        uint token1Funding,
+        uint token2Funding,
+        address ethTokenMem,
+        uint ethUSDPrice
+    ) internal view returns (uint fundedValueUSD)
+    {
+        // We require there to exist ethToken-Token auctions
+        // R3.1
+        require(getAuctionIndex(token1, ethTokenMem) > 0);
+
+        // R3.2
+        require(getAuctionIndex(token2, ethTokenMem) > 0);
+
+        // Price of Token 1
+        uint priceToken1Num;
+        uint priceToken1Den;
+        (priceToken1Num, priceToken1Den) = getPriceOfTokenInLastAuction(token1);
+
+        // Price of Token 2
+        uint priceToken2Num;
+        uint priceToken2Den;
+        (priceToken2Num, priceToken2Den) = getPriceOfTokenInLastAuction(token2);
+
+        // Compute funded value in ethToken and USD
+        // 10^30 * 10^30 = 10^60
+        uint fundedValueETH = add(
+            mul(token1Funding, priceToken1Num) / priceToken1Den,
+            token2Funding * priceToken2Num / priceToken2Den
+        );
+
+        fundedValueUSD = mul(fundedValueETH, ethUSDPrice);
+    }
+
+    function addTokenPairSecondPart(address token1, address token2, uint token1Funding, uint token2Funding) internal {
+        balances[token1][msg.sender] = sub(balances[token1][msg.sender], token1Funding);
+        balances[token2][msg.sender] = sub(balances[token2][msg.sender], token2Funding);
+
+        // Fee mechanism, fees are added to extraTokens
+        uint token1FundingAfterFee = settleFee(token1, token2, 1, token1Funding);
+        uint token2FundingAfterFee = settleFee(token2, token1, 1, token2Funding);
+
+        // Update other variables
+        sellVolumesCurrent[token1][token2] = token1FundingAfterFee;
+        sellVolumesCurrent[token2][token1] = token2FundingAfterFee;
+        sellerBalances[token1][token2][1][msg.sender] = token1FundingAfterFee;
+        sellerBalances[token2][token1][1][msg.sender] = token2FundingAfterFee;
+
+        setAuctionStart(token1, token2, WAITING_PERIOD_NEW_TOKEN_PAIR);
+        emit NewTokenPair(token1, token2);
+    }
+
+    function issueFrts(
+        address primaryToken,
+        address secondaryToken,
+        uint x,
+        uint auctionIndex,
+        uint bal,
+        address user
+    )
+        internal
+        returns (uint frtsIssued)
+    {
+        if (approvedTokens[primaryToken] && approvedTokens[secondaryToken]) {
+            address ethTokenMem = ethToken;
+            // Get frts issued based on ETH price of returned tokens
+            if (primaryToken == ethTokenMem) {
+                frtsIssued = bal;
+            } else if (secondaryToken == ethTokenMem) {
+                // 10^30 * 10^39 = 10^66
+                frtsIssued = x;
+            } else {
+                // Neither token is ethToken, so we use getHhistoricalPriceOracle()
+                uint pastNum;
+                uint pastDen;
+                (pastNum, pastDen) = getPriceInPastAuction(primaryToken, ethTokenMem, auctionIndex - 1);
+                // 10^30 * 10^35 = 10^65
+                frtsIssued = mul(bal, pastNum) / pastDen;
+            }
+
+            if (frtsIssued > 0) {
+                // Issue frtToken
+                frtToken.mintTokens(user, frtsIssued);
+            }
         }
     }
 
@@ -633,58 +1154,7 @@ contract DutchExchange is DxUpgrade, TokenWhitelist, EthOracle {
         }
     }
 
-    function getFeeRatio(address user)
-        public
-        view
-        returns (
-        // feeRatio < 10^4
-        uint num,
-        uint den
-    )
-    {
-        uint totalSupply = frtToken.totalSupply();
-        uint lockedFrt = frtToken.lockedTokenBalances(user);
-
-        /*
-          Fee Model:
-            locked FRT range     Fee
-            -----------------   ------
-            [0, 0.01%)           0.5%
-            [0.01%, 0.1%)        0.4%
-            [0.1%, 1%)           0.3%
-            [1%, 10%)            0.2%
-            [10%, 100%)          0.1%
-        */
-
-        if (lockedFrt * 10000 < totalSupply || totalSupply == 0) {
-            // Maximum fee, if user has locked less than 0.01% of the total FRT
-            // Fee: 0.5%
-            num = 1;
-            den = 200;
-        } else if (lockedFrt * 1000 < totalSupply) {
-            // If user has locked more than 0.01% and less than 0.1% of the total FRT
-            // Fee: 0.4%
-            num = 1;
-            den = 250;
-        } else if (lockedFrt * 100 < totalSupply) {
-            // If user has locked more than 0.1% and less than 1% of the total FRT
-            // Fee: 0.3%
-            num = 3;
-            den = 1000;
-        } else if (lockedFrt * 10 < totalSupply) {
-            // If user has locked more than 1% and less than 10% of the total FRT
-            // Fee: 0.2%
-            num = 1;
-            den = 500;
-        } else {
-            // If user has locked more than 10% of the total FRT
-            // Fee: 0.1%
-            num = 1;
-            den = 1000;
-        }
-    }
-
-    /// @dev clears an Auction
+/// @dev clears an Auction
     /// @param sellToken sellToken of the auction
     /// @param buyToken  buyToken of the auction
     /// @param auctionIndex of the auction to be cleared.
@@ -697,7 +1167,7 @@ contract DutchExchange is DxUpgrade, TokenWhitelist, EthOracle {
 
         // Update closing price
         if (sellVolume > 0) {
-            closingPrices[sellToken][buyToken][auctionIndex] = fraction(buyVolume, sellVolume);
+            closingPrices[sellToken][buyToken][auctionIndex] = Fraction(buyVolume, sellVolume);
         }
 
         // if (opposite is 0 auction OR price = 0 OR opposite auction cleared)
@@ -707,7 +1177,7 @@ contract DutchExchange is DxUpgrade, TokenWhitelist, EthOracle {
             uint buyVolumeOpp = buyVolumes[buyToken][sellToken];
             if (closingPriceOppDen == 0 && sellVolumeOpp > 0) {
                 // Save opposite price
-                closingPrices[buyToken][sellToken][auctionIndex] = fraction(buyVolumeOpp, sellVolumeOpp);
+                closingPrices[buyToken][sellToken][auctionIndex] = Fraction(buyVolumeOpp, sellVolumeOpp);
             }
 
             uint sellVolumeNext = sellVolumesNext[sellToken][buyToken];
@@ -767,147 +1237,6 @@ contract DutchExchange is DxUpgrade, TokenWhitelist, EthOracle {
         }
     }
 
-    //@ dev returns price in units [token2]/[token1]
-    //@ param token1 first token for price calculation
-    //@ param token2 second token for price calculation
-    //@ param auctionIndex index for the auction to get the averaged price from
-    function getPriceInPastAuction(address token1, address token2, uint auctionIndex)
-        public
-        view
-        returns (
-        // price < 10^31
-        uint num,
-        uint den
-    )
-    {
-        if (token1 == token2) {
-            // C1
-            num = 1;
-            den = 1;
-        } else {
-            // C2
-            // R2.1
-            require(auctionIndex >= 0);
-
-            // C3
-            // R3.1
-            require(auctionIndex <= getAuctionIndex(token1, token2));
-            // auction still running
-
-            uint i = 0;
-            bool correctPair = false;
-            fraction memory closingPriceToken1;
-            fraction memory closingPriceToken2;
-
-            while (!correctPair) {
-                closingPriceToken2 = closingPrices[token2][token1][auctionIndex - i];
-                closingPriceToken1 = closingPrices[token1][token2][auctionIndex - i];
-
-                if (closingPriceToken1.num > 0 && closingPriceToken1.den > 0 || closingPriceToken2.num > 0 && closingPriceToken2.den > 0) {
-                    correctPair = true;
-                }
-                i++;
-            }
-
-            // At this point at least one closing price is strictly positive
-            // If only one is positive, we want to output that
-            if (closingPriceToken1.num == 0 || closingPriceToken1.den == 0) {
-                num = closingPriceToken2.den;
-                den = closingPriceToken2.num;
-            } else if (closingPriceToken2.num == 0 || closingPriceToken2.den == 0) {
-                num = closingPriceToken1.num;
-                den = closingPriceToken1.den;
-            } else {
-                // If both prices are positive, output weighted average
-                num = closingPriceToken2.den + closingPriceToken1.num;
-                den = closingPriceToken2.num + closingPriceToken1.den;
-            }
-        }
-    }
-
-    /// @dev Gives best estimate for market price of a token in ETH of any price oracle on the Ethereum network
-    /// @param token address of ERC-20 token
-    /// @return Weighted average of closing prices of opposite Token-ethToken auctions, based on their sellVolume
-    function getPriceOfTokenInLastAuction(address token)
-        public
-        view
-        returns (
-        // price < 10^31
-        uint num,
-        uint den
-    )
-    {
-        uint latestAuctionIndex = getAuctionIndex(token, ethToken);
-        // getPriceInPastAuction < 10^30
-        (num, den) = getPriceInPastAuction(token, ethToken, latestAuctionIndex - 1);
-    }
-
-    function getCurrentAuctionPrice(address sellToken, address buyToken, uint auctionIndex)
-        public
-        view
-        returns (
-        // price < 10^37
-        uint num,
-        uint den
-    )
-    {
-        fraction memory closingPrice = closingPrices[sellToken][buyToken][auctionIndex];
-
-        if (closingPrice.den != 0) {
-            // Auction has closed
-            (num, den) = (closingPrice.num, closingPrice.den);
-        } else if (auctionIndex > getAuctionIndex(sellToken, buyToken)) {
-            (num, den) = (0, 0);
-        } else {
-            // Auction is running
-            uint pastNum;
-            uint pastDen;
-            (pastNum, pastDen) = getPriceInPastAuction(sellToken, buyToken, auctionIndex - 1);
-
-            // If we're calling the function into an unstarted auction,
-            // it will return the starting price of that auction
-            uint timeElapsed = atleastZero(int(now - getAuctionStart(sellToken, buyToken)));
-
-            // The numbers below are chosen such that
-            // P(0 hrs) = 2 * lastClosingPrice, P(6 hrs) = lastClosingPrice, P(>=24 hrs) = 0
-
-            // 10^5 * 10^31 = 10^36
-            num = atleastZero(int((86400 - timeElapsed) * pastNum));
-            // 10^6 * 10^31 = 10^37
-            den = mul((timeElapsed + 43200), pastDen);
-
-            if (mul(num, sellVolumesCurrent[sellToken][buyToken]) <= mul(den, buyVolumes[sellToken][buyToken])) {
-                num = buyVolumes[sellToken][buyToken];
-                den = sellVolumesCurrent[sellToken][buyToken];
-            }
-        }
-    }
-
-    function depositAndSell(address sellToken, address buyToken, uint amount)
-        external
-        returns (uint newBal, uint auctionIndex, uint newSellerBal)
-    {
-        newBal = deposit(sellToken, amount);
-        (auctionIndex, newSellerBal) = postSellOrder(sellToken, buyToken, 0, amount);
-    }
-
-    function claimAndWithdraw(address sellToken, address buyToken, address user, uint auctionIndex, uint amount)
-        external
-        returns (uint returned, uint frtsIssued, uint newBal)
-    {
-        (returned, frtsIssued) = claimSellerFunds(sellToken, buyToken, user, auctionIndex);
-        newBal = withdraw(buyToken, amount);
-    }
-
-    // > Helper fns
-    function getTokenOrder(address token1, address token2) public pure returns (address, address) {
-        if (token2 < token1) {
-            (token1, token2) = (token2, token1);
-        }
-
-        return (token1, token2);
-    }
-
     function setAuctionStart(address token1, address token2, uint value) internal {
         (token1, token2) = getTokenOrder(token1, token2);
         uint auctionStart = now + value;
@@ -923,179 +1252,17 @@ contract DutchExchange is DxUpgrade, TokenWhitelist, EthOracle {
         }
     }
 
-    function getAuctionStart(address token1, address token2) public view returns (uint auctionStart) {
-        (token1, token2) = getTokenOrder(token1, token2);
-        auctionStart = auctionStarts[token1][token2];
-    }
-
     function setAuctionIndex(address token1, address token2) internal {
         (token1, token2) = getTokenOrder(token1, token2);
         latestAuctionIndices[token1][token2] += 1;
-    }
-
-    function getAuctionIndex(address token1, address token2) public view returns (uint auctionIndex) {
-        (token1, token2) = getTokenOrder(token1, token2);
-        auctionIndex = latestAuctionIndices[token1][token2];
-    }
-
-    function getRunningTokenPairs(address[] calldata tokens)
-        external
-        view
-        returns (address[] memory tokens1, address[] memory tokens2)
-    {
-        uint arrayLength;
-
-        for (uint k = 0; k < tokens.length - 1; k++) {
-            for (uint l = k + 1; l < tokens.length; l++) {
-                if (getAuctionIndex(tokens[k], tokens[l]) > 0) {
-                    arrayLength++;
-                }
-            }
-        }
-
-        tokens1 = new address[](arrayLength);
-        tokens2 = new address[](arrayLength);
-
-        uint h;
-
-        for (uint i = 0; i < tokens.length - 1; i++) {
-            for (uint j = i + 1; j < tokens.length; j++) {
-                if (getAuctionIndex(tokens[i], tokens[j]) > 0) {
-                    tokens1[h] = tokens[i];
-                    tokens2[h] = tokens[j];
-                    h++;
-                }
-            }
-        }
-    }
-
-    /// @dev for quick overview of possible sellerBalances to calculate the possible withdraw tokens
-    /// @param auctionSellToken is the sellToken defining an auctionPair
-    /// @param auctionBuyToken is the buyToken defining an auctionPair
-    /// @param user is the user who wants to his tokens
-    /// @param lastNAuctions how many auctions will be checked. 0 means all
-    //@returns returns sellbal for all indices for all tokenpairs
-    function getIndicesWithClaimableTokensForSellers(
-        address auctionSellToken,
-        address auctionBuyToken,
-        address user,
-        uint lastNAuctions
-    ) external view returns (uint[] memory indices, uint[] memory usersBalances) {
-        uint runningAuctionIndex = getAuctionIndex(auctionSellToken, auctionBuyToken);
-
-        uint arrayLength;
-
-        uint startingIndex = lastNAuctions == 0 ? 1 : runningAuctionIndex - lastNAuctions + 1;
-
-        for (uint j = startingIndex; j <= runningAuctionIndex; j++) {
-            if (sellerBalances[auctionSellToken][auctionBuyToken][j][user] > 0) {
-                arrayLength++;
-            }
-        }
-
-        indices = new uint[](arrayLength);
-        usersBalances = new uint[](arrayLength);
-
-        uint k;
-
-        for (uint i = startingIndex; i <= runningAuctionIndex; i++) {
-            if (sellerBalances[auctionSellToken][auctionBuyToken][i][user] > 0) {
-                indices[k] = i;
-                usersBalances[k] = sellerBalances[auctionSellToken][auctionBuyToken][i][user];
-                k++;
-            }
-        }
-    }
-
-    /// @dev for quick overview of current sellerBalances for a user
-    /// @param auctionSellTokens are the sellTokens defining an auctionPair
-    /// @param auctionBuyTokens are the buyTokens defining an auctionPair
-    /// @param user is the user who wants to his tokens
-    function getSellerBalancesOfCurrentAuctions(
-        address[] calldata auctionSellTokens,
-        address[] calldata auctionBuyTokens,
-        address user
-    ) external view returns (uint[] memory) {
-        uint length = auctionSellTokens.length;
-        uint length2 = auctionBuyTokens.length;
-        require(length == length2);
-
-        uint[] memory sellersBalances = new uint[](length);
-
-        for (uint i = 0; i < length; i++) {
-            uint runningAuctionIndex = getAuctionIndex(auctionSellTokens[i], auctionBuyTokens[i]);
-            sellersBalances[i] = sellerBalances[auctionSellTokens[i]][auctionBuyTokens[i]][runningAuctionIndex][user];
-        }
-
-        return sellersBalances;
-    }
-
-    /// @dev for quick overview of possible buyerBalances to calculate the possible withdraw tokens
-    /// @param auctionSellToken is the sellToken defining an auctionPair
-    /// @param auctionBuyToken is the buyToken defining an auctionPair
-    /// @param user is the user who wants to his tokens
-    /// @param lastNAuctions how many auctions will be checked. 0 means all
-    //@returns returns sellbal for all indices for all tokenpairs
-    function getIndicesWithClaimableTokensForBuyers(
-        address auctionSellToken,
-        address auctionBuyToken,
-        address user,
-        uint lastNAuctions
-    ) external view returns (uint[] memory indices, uint[] memory usersBalances) {
-        uint runningAuctionIndex = getAuctionIndex(auctionSellToken, auctionBuyToken);
-
-        uint arrayLength;
-
-        uint startingIndex = lastNAuctions == 0 ? 1 : runningAuctionIndex - lastNAuctions + 1;
-
-        for (uint j = startingIndex; j <= runningAuctionIndex; j++) {
-            if (buyerBalances[auctionSellToken][auctionBuyToken][j][user] > 0) {
-                arrayLength++;
-            }
-        }
-
-        indices = new uint[](arrayLength);
-        usersBalances = new uint[](arrayLength);
-
-        uint k;
-
-        for (uint i = startingIndex; i <= runningAuctionIndex; i++) {
-            if (buyerBalances[auctionSellToken][auctionBuyToken][i][user] > 0) {
-                indices[k] = i;
-                usersBalances[k] = buyerBalances[auctionSellToken][auctionBuyToken][i][user];
-                k++;
-            }
-        }
-    }
-
-    /// @dev for quick overview of current sellerBalances for a user
-    /// @param auctionSellTokens are the sellTokens defining an auctionPair
-    /// @param auctionBuyTokens are the buyTokens defining an auctionPair
-    /// @param user is the user who wants to his tokens
-    function getBuyerBalancesOfCurrentAuctions(
-        address[] calldata auctionSellTokens,
-        address[] calldata auctionBuyTokens,
-        address user
-    ) external view returns (uint[] memory) {
-        uint length = auctionSellTokens.length;
-        uint length2 = auctionBuyTokens.length;
-        require(length == length2);
-
-        uint[] memory buyersBalances = new uint[](length);
-
-        for (uint i = 0; i < length; i++) {
-            uint runningAuctionIndex = getAuctionIndex(auctionSellTokens[i], auctionBuyTokens[i]);
-            buyersBalances[i] = buyerBalances[auctionSellTokens[i]][auctionBuyTokens[i]][runningAuctionIndex][user];
-        }
-
-        return buyersBalances;
     }
 
     function checkLengthsForSeveralAuctionClaiming(
         address[] memory auctionSellTokens,
         address[] memory auctionBuyTokens,
         uint[] memory auctionIndices
-    ) internal pure returns (uint length) {
+    ) internal pure returns (uint length)
+    {
         length = auctionSellTokens.length;
         uint length2 = auctionBuyTokens.length;
         require(length == length2);
@@ -1103,127 +1270,7 @@ contract DutchExchange is DxUpgrade, TokenWhitelist, EthOracle {
         uint length3 = auctionIndices.length;
         require(length2 == length3);
     }
-
-    /// @dev for multiple claims
-    /// @param auctionSellTokens are the sellTokens defining an auctionPair
-    /// @param auctionBuyTokens are the buyTokens defining an auctionPair
-    /// @param auctionIndices are the auction indices on which an token should be claimedAmounts
-    /// @param user is the user who wants to his tokens
-    function claimTokensFromSeveralAuctionsAsSeller(
-        address[] calldata auctionSellTokens,
-        address[] calldata auctionBuyTokens,
-        uint[] calldata auctionIndices,
-        address user
-    ) external returns (uint[] memory, uint[] memory) {
-        uint length = checkLengthsForSeveralAuctionClaiming(auctionSellTokens, auctionBuyTokens, auctionIndices);
-
-        uint[] memory claimAmounts = new uint[](length);
-        uint[] memory frtsIssuedList = new uint[](length);
-
-        for (uint i = 0; i < length; i++) {
-            (claimAmounts[i], frtsIssuedList[i]) = claimSellerFunds(
-                auctionSellTokens[i],
-                auctionBuyTokens[i],
-                user,
-                auctionIndices[i]
-            );
-        }
-
-        return (claimAmounts, frtsIssuedList);
-    }
-
-    /// @dev for multiple claims
-    /// @param auctionSellTokens are the sellTokens defining an auctionPair
-    /// @param auctionBuyTokens are the buyTokens defining an auctionPair
-    /// @param auctionIndices are the auction indices on which an token should be claimedAmounts
-    /// @param user is the user who wants to his tokens
-    function claimTokensFromSeveralAuctionsAsBuyer(
-        address[] calldata auctionSellTokens,
-        address[] calldata auctionBuyTokens,
-        uint[] calldata auctionIndices,
-        address user
-    ) external returns (uint[] memory, uint[] memory) {
-        uint length = checkLengthsForSeveralAuctionClaiming(auctionSellTokens, auctionBuyTokens, auctionIndices);
-
-        uint[] memory claimAmounts = new uint[](length);
-        uint[] memory frtsIssuedList = new uint[](length);
-
-        for (uint i = 0; i < length; i++) {
-            (claimAmounts[i], frtsIssuedList[i]) = claimBuyerFunds(
-                auctionSellTokens[i],
-                auctionBuyTokens[i],
-                user,
-                auctionIndices[i]
-            );
-        }
-
-        return (claimAmounts, frtsIssuedList);
-    }
-
-    /// @dev for multiple withdraws
-    /// @param auctionSellTokens are the sellTokens defining an auctionPair
-    /// @param auctionBuyTokens are the buyTokens defining an auctionPair
-    /// @param auctionIndices are the auction indices on which an token should be claimedAmounts
-    function claimAndWithdrawTokensFromSeveralAuctionsAsSeller(
-        address[] calldata auctionSellTokens,
-        address[] calldata auctionBuyTokens,
-        uint[] calldata auctionIndices
-    ) external returns (uint[] memory, uint frtsIssued) {
-        uint length = checkLengthsForSeveralAuctionClaiming(auctionSellTokens, auctionBuyTokens, auctionIndices);
-
-        uint[] memory claimAmounts = new uint[](length);
-        uint claimFrts = 0;
-
-        for (uint i = 0; i < length; i++) {
-            (claimAmounts[i], claimFrts) = claimSellerFunds(
-                auctionSellTokens[i],
-                auctionBuyTokens[i],
-                msg.sender,
-                auctionIndices[i]
-            );
-
-            frtsIssued += claimFrts;
-
-            withdraw(auctionBuyTokens[i], claimAmounts[i]);
-        }
-
-        return (claimAmounts, frtsIssued);
-    }
-
-    /// @dev for multiple withdraws
-    /// @param auctionSellTokens are the sellTokens defining an auctionPair
-    /// @param auctionBuyTokens are the buyTokens defining an auctionPair
-    /// @param auctionIndices are the auction indices on which an token should be claimedAmounts
-    function claimAndWithdrawTokensFromSeveralAuctionsAsBuyer(
-        address[] calldata auctionSellTokens,
-        address[] calldata auctionBuyTokens,
-        uint[] calldata auctionIndices
-    ) external returns (uint[] memory, uint frtsIssued) {
-        uint length = checkLengthsForSeveralAuctionClaiming(auctionSellTokens, auctionBuyTokens, auctionIndices);
-
-        uint[] memory claimAmounts = new uint[](length);
-        uint claimFrts = 0;
-
-        for (uint i = 0; i < length; i++) {
-            (claimAmounts[i], claimFrts) = claimBuyerFunds(
-                auctionSellTokens[i],
-                auctionBuyTokens[i],
-                msg.sender,
-                auctionIndices[i]
-            );
-
-            frtsIssued += claimFrts;
-
-            withdraw(auctionSellTokens[i], claimAmounts[i]);
-        }
-
-        return (claimAmounts, frtsIssued);
-    }
-
-    function getMasterCopy() external view returns (address) {
-        return masterCopy;
-    }
-
+    
     // > Events
     event NewDeposit(address indexed token, uint amount);
 

--- a/contracts/DutchExchangeProxy.sol
+++ b/contracts/DutchExchangeProxy.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.5.2;
 
 import "@gnosis.pm/util-contracts/contracts/Proxy.sol";
 
+
 contract DutchExchangeProxy is Proxy {
     constructor(address _masterCopy) public Proxy(_masterCopy) {}
 }

--- a/contracts/DxDevDependencies.sol
+++ b/contracts/DxDevDependencies.sol
@@ -21,4 +21,5 @@ import "./TokenFRTProxy.sol";
 import "./DutchExchange.sol";
 import "./DutchExchangeProxy.sol";
 
+
 contract DxDevDependencies {}

--- a/contracts/ForTestingOnly/InternalTests.sol
+++ b/contracts/ForTestingOnly/InternalTests.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.5.2;
 
 import "../DutchExchange.sol";
 
+
 contract InternalTests is DutchExchange {
     function settleFeePub(address primaryToken, address secondaryToken, uint auctionIndex, address user, uint amount)
         public

--- a/contracts/ForTestingOnly/InternalTests.sol
+++ b/contracts/ForTestingOnly/InternalTests.sol
@@ -4,13 +4,6 @@ import "../DutchExchange.sol";
 
 
 contract InternalTests is DutchExchange {
-    function settleFeePub(address primaryToken, address secondaryToken, uint auctionIndex, address user, uint amount)
-        public
-        returns (uint)
-    {
-        return super.settleFee(primaryToken, secondaryToken, auctionIndex, amount);
-    }
-
     constructor(
         TokenFRT _FRT,
         TokenOWL _OWL,
@@ -20,7 +13,22 @@ contract InternalTests is DutchExchange {
         uint _thresholdNewTokenPair,
         uint _thresholdNewAuction
     ) public {
-        setupDutchExchange(_FRT, _OWL, _owner, _ETH, _ETHUSDOracle, _thresholdNewTokenPair, _thresholdNewAuction);
+        setupDutchExchange(
+            _FRT,
+            _OWL,
+            _owner,
+            _ETH,
+            _ETHUSDOracle,
+            _thresholdNewTokenPair,
+            _thresholdNewAuction
+        );
+    }
+
+    function settleFeePub(address primaryToken, address secondaryToken, uint auctionIndex, address user, uint amount)
+        public
+        returns (uint)
+    {
+        return super.settleFee(primaryToken, secondaryToken, auctionIndex, amount);
     }
 
     function getFeeRatioForJS(address user) public view returns (uint feeRatioNum, uint feeRatioDen) {

--- a/contracts/ForTestingOnly/TokenOMG.sol
+++ b/contracts/ForTestingOnly/TokenOMG.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.5.2;
 
 import "@gnosis.pm/util-contracts/contracts/GnosisStandardToken.sol";
 
+
 contract TokenOMG is GnosisStandardToken {
     string public constant symbol = "OMG";
     string public constant name = "OMG Test Token";

--- a/contracts/ForTestingOnly/TokenRDN.sol
+++ b/contracts/ForTestingOnly/TokenRDN.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.5.2;
 
 import "@gnosis.pm/util-contracts/contracts/GnosisStandardToken.sol";
 
+
 contract TokenRDN is GnosisStandardToken {
     string public constant symbol = "RDN";
     string public constant name = "Raiden network tokens";

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -6,7 +6,8 @@ contract Migrations {
     uint public last_completed_migration;
 
     modifier restricted() {
-        if (msg.sender == owner) _;
+        if (msg.sender == owner)
+            _;
     }
 
     constructor() public {

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.5.2;
 
+
 contract Migrations {
     address public owner;
     uint public last_completed_migration;

--- a/contracts/Oracle/DSAuth.sol
+++ b/contracts/Oracle/DSAuth.sol
@@ -1,13 +1,16 @@
 pragma solidity ^0.5.2;
 
+
 contract DSAuthority {
     function canCall(address src, address dst, bytes4 sig) public view returns (bool);
 }
+
 
 contract DSAuthEvents {
     event LogSetAuthority(address indexed authority);
     event LogSetOwner(address indexed owner);
 }
+
 
 contract DSAuth is DSAuthEvents {
     DSAuthority public authority;

--- a/contracts/Oracle/DSMath.sol
+++ b/contracts/Oracle/DSMath.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.5.2;
 
+
 contract DSMath {
     /*
     standard uint256 functions
@@ -24,6 +25,7 @@ contract DSMath {
     function min(uint256 x, uint256 y) internal pure returns (uint256 z) {
         return x <= y ? x : y;
     }
+
     function max(uint256 x, uint256 y) internal pure returns (uint256 z) {
         return x >= y ? x : y;
     }
@@ -51,6 +53,7 @@ contract DSMath {
     function hmin(uint128 x, uint128 y) internal pure returns (uint128 z) {
         return x <= y ? x : y;
     }
+
     function hmax(uint128 x, uint128 y) internal pure returns (uint128 z) {
         return x >= y ? x : y;
     }
@@ -62,6 +65,7 @@ contract DSMath {
     function imin(int256 x, int256 y) internal pure returns (int256 z) {
         return x <= y ? x : y;
     }
+
     function imax(int256 x, int256 y) internal pure returns (int256 z) {
         return x >= y ? x : y;
     }
@@ -91,6 +95,7 @@ contract DSMath {
     function wmin(uint128 x, uint128 y) internal pure returns (uint128) {
         return hmin(x, y);
     }
+
     function wmax(uint128 x, uint128 y) internal pure returns (uint128) {
         return hmax(x, y);
     }
@@ -147,6 +152,7 @@ contract DSMath {
     function rmin(uint128 x, uint128 y) internal pure returns (uint128) {
         return hmin(x, y);
     }
+
     function rmax(uint128 x, uint128 y) internal pure returns (uint128) {
         return hmax(x, y);
     }

--- a/contracts/Oracle/DSNote.sol
+++ b/contracts/Oracle/DSNote.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.5.2;
 
+
 contract DSNote {
     event LogNote(bytes4 indexed sig, address indexed guy, bytes32 indexed foo, bytes32 bar, uint wad, bytes fax);
 

--- a/contracts/Oracle/DSNote.sol
+++ b/contracts/Oracle/DSNote.sol
@@ -14,7 +14,7 @@ contract DSNote {
     modifier note {
         bytes32 foo;
         bytes32 bar;
-
+        // solium-disable-next-line security/no-inline-assembly
         assembly {
             foo := calldataload(4)
             bar := calldataload(36)

--- a/contracts/Oracle/DSNote.sol
+++ b/contracts/Oracle/DSNote.sol
@@ -20,7 +20,14 @@ contract DSNote {
             bar := calldataload(36)
         }
 
-        emit LogNote(msg.sig, msg.sender, foo, bar, msg.value, msg.data);
+        emit LogNote(
+            msg.sig,
+            msg.sender,
+            foo,
+            bar,
+            msg.value,
+            msg.data
+        );
 
         _;
     }

--- a/contracts/Oracle/DSNote.sol
+++ b/contracts/Oracle/DSNote.sol
@@ -2,7 +2,14 @@ pragma solidity ^0.5.2;
 
 
 contract DSNote {
-    event LogNote(bytes4 indexed sig, address indexed guy, bytes32 indexed foo, bytes32 bar, uint wad, bytes fax);
+    event LogNote(
+        bytes4 indexed sig,
+        address indexed guy,
+        bytes32 indexed foo,
+        bytes32 bar,
+        uint wad,
+        bytes fax
+    );
 
     modifier note {
         bytes32 foo;

--- a/contracts/Oracle/DSThing.sol
+++ b/contracts/Oracle/DSThing.sol
@@ -4,4 +4,5 @@ import "../Oracle/DSMath.sol";
 import "../Oracle/DSAuth.sol";
 import "../Oracle/DSNote.sol";
 
+
 contract DSThing is DSAuth, DSNote, DSMath {}

--- a/contracts/Oracle/DSValue.sol
+++ b/contracts/Oracle/DSValue.sol
@@ -2,21 +2,25 @@ pragma solidity ^0.5.2;
 
 import "../Oracle/DSThing.sol";
 
+
 contract DSValue is DSThing {
     bool has;
     bytes32 val;
     function peek() public view returns (bytes32, bool) {
         return (val, has);
     }
+
     function read() public view returns (bytes32) {
         (bytes32 wut, bool _has) = peek();
         assert(_has);
         return wut;
     }
+
     function poke(bytes32 wut) public payable note auth {
         val = wut;
         has = true;
     }
+
     function void() public payable note auth {
         // unset the value
         has = false;

--- a/contracts/Oracle/Medianizer.sol
+++ b/contracts/Oracle/Medianizer.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.5.2;
 
 import "./DSValue.sol";
 
+
 contract Medianizer is DSValue {
     mapping(bytes12 => address) public values;
     mapping(address => bytes12) public indexes;

--- a/contracts/Oracle/Medianizer.sol
+++ b/contracts/Oracle/Medianizer.sol
@@ -79,7 +79,8 @@ contract Medianizer is DSValue {
             }
         }
 
-        if (ctr < minimun) return (val, false);
+        if (ctr < minimun)
+            return (val, false);
 
         bytes32 value;
         if (ctr % 2 == 0) {

--- a/contracts/Oracle/PriceFeed.sol
+++ b/contracts/Oracle/PriceFeed.sol
@@ -12,6 +12,7 @@ pragma solidity ^0.5.2;
 
 import "../Oracle/DSThing.sol";
 
+
 contract PriceFeed is DSThing {
     uint128 val;
     uint32 public zzz;

--- a/contracts/Oracle/PriceOracleInterface.sol
+++ b/contracts/Oracle/PriceOracleInterface.sol
@@ -25,6 +25,7 @@ contract PriceOracleInterface {
         owner = _owner;
         priceFeedSource = _priceFeedSource;
     }
+    
     /// @dev gives the owner the possibility to put the Interface into an emergencyMode, which will
     /// output always a price of 600 USD. This gives everyone time to set up a new pricefeed.
     function raiseEmergency(bool _emergencyMode) public onlyOwner {

--- a/contracts/Oracle/PriceOracleInterface.sol
+++ b/contracts/Oracle/PriceOracleInterface.sol
@@ -7,6 +7,7 @@ This contract is the interface between the MakerDAO priceFeed and our DX platfor
 import "../Oracle/PriceFeed.sol";
 import "../Oracle/Medianizer.sol";
 
+
 contract PriceOracleInterface {
     address public priceFeedSource;
     address public owner;

--- a/contracts/TokenFRT.sol
+++ b/contracts/TokenFRT.sol
@@ -98,6 +98,7 @@ contract TokenFRT is Proxied, GnosisStandardToken {
             return b;
         }
     }
+    
     /// @dev Returns whether an add operation causes an overflow
     /// @param a First addend
     /// @param b Second addend

--- a/contracts/TokenFRT.sol
+++ b/contracts/TokenFRT.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.5.2;
 import "@gnosis.pm/util-contracts/contracts/Proxy.sol";
 import "@gnosis.pm/util-contracts/contracts/GnosisStandardToken.sol";
 
+
 /// @title Standard token contract with overflow protection
 contract TokenFRT is Proxied, GnosisStandardToken {
     address public owner;

--- a/contracts/TokenFRT.sol
+++ b/contracts/TokenFRT.sol
@@ -12,7 +12,7 @@ contract TokenFRT is Proxied, GnosisStandardToken {
     string public constant name = "Magnolia Token";
     uint8 public constant decimals = 18;
 
-    struct unlockedToken {
+    struct UnlockedToken {
         uint amountUnlocked;
         uint withdrawalTime;
     }
@@ -22,8 +22,8 @@ contract TokenFRT is Proxied, GnosisStandardToken {
      */
     address public minter;
 
-    // user => unlockedToken
-    mapping(address => unlockedToken) public unlockedTokens;
+    // user => UnlockedToken
+    mapping(address => UnlockedToken) public unlockedTokens;
 
     // user => amount
     mapping(address => uint) public lockedTokenBalances;

--- a/contracts/TokenFRTProxy.sol
+++ b/contracts/TokenFRTProxy.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.5.2;
 import "@gnosis.pm/util-contracts/contracts/Proxy.sol";
 import "@gnosis.pm/util-contracts/contracts/GnosisStandardToken.sol";
 
+
 contract TokenFRTProxy is Proxy, GnosisStandardToken {
     /// @dev State variables remain for Blockchain exploring Proxied Token contracts
     address public owner;

--- a/contracts/base/AuctioneerManaged.sol
+++ b/contracts/base/AuctioneerManaged.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.5.2;
 
+
 contract AuctioneerManaged {
     // auctioneer has the power to manage some variables
     address public auctioneer;

--- a/contracts/base/DxMath.sol
+++ b/contracts/base/DxMath.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.5.2;
 
+
 contract DxMath {
     // > Math fns
     function min(uint a, uint b) public pure returns (uint) {

--- a/contracts/base/DxMath.sol
+++ b/contracts/base/DxMath.sol
@@ -18,6 +18,7 @@ contract DxMath {
             return uint(a);
         }
     }
+    
     /// @dev Returns whether an add operation causes an overflow
     /// @param a First addend
     /// @param b Second addend

--- a/contracts/base/DxUpgrade.sol
+++ b/contracts/base/DxUpgrade.sol
@@ -4,6 +4,7 @@ import "./DxMath.sol";
 import "./AuctioneerManaged.sol";
 import "@gnosis.pm/util-contracts/contracts/Proxy.sol";
 
+
 contract DxUpgrade is Proxied, AuctioneerManaged, DxMath {
     uint constant WAITING_PERIOD_CHANGE_MASTERCOPY = 30 days;
 

--- a/contracts/base/EthOracle.sol
+++ b/contracts/base/EthOracle.sol
@@ -4,6 +4,7 @@ import "../Oracle/PriceOracleInterface.sol";
 import "./AuctioneerManaged.sol";
 import "./DxMath.sol";
 
+
 contract EthOracle is AuctioneerManaged, DxMath {
     uint constant WAITING_PERIOD_CHANGE_ORACLE = 30 days;
 

--- a/contracts/base/TokenWhitelist.sol
+++ b/contracts/base/TokenWhitelist.sol
@@ -11,13 +11,6 @@ contract TokenWhitelist is AuctioneerManaged {
 
     event Approval(address indexed token, bool approved);
 
-    function updateApprovalOfToken(address[] memory token, bool approved) public onlyAuctioneer {
-        for (uint i = 0; i < token.length; i++) {
-            approvedTokens[token[i]] = approved;
-            emit Approval(token[i], approved);
-        }
-    }
-
     /// @dev for quick overview of approved Tokens
     /// @param addressesToCheck are the ERC-20 token addresses to be checked whether they are approved
     function getApprovedAddressesOfList(address[] calldata addressesToCheck) external view returns (bool[] memory) {
@@ -31,4 +24,12 @@ contract TokenWhitelist is AuctioneerManaged {
 
         return isApproved;
     }
+    
+    function updateApprovalOfToken(address[] memory token, bool approved) public onlyAuctioneer {
+        for (uint i = 0; i < token.length; i++) {
+            approvedTokens[token[i]] = approved;
+            emit Approval(token[i], approved);
+        }
+    }
+
 }

--- a/contracts/base/TokenWhitelist.sol
+++ b/contracts/base/TokenWhitelist.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.5.2;
 
 import "./AuctioneerManaged.sol";
 
+
 contract TokenWhitelist is AuctioneerManaged {
     // Mapping that stores the tokens, which are approved
     // Only tokens approved by auctioneer generate frtToken tokens

--- a/test/dutchExchange-UpdateExchangeParams.spec.js
+++ b/test/dutchExchange-UpdateExchangeParams.spec.js
@@ -89,7 +89,6 @@ contract('DutchExchange updating exchange params', (accounts) => {
     assert.notStrictEqual(auctioneer, acc, 'account should not be DutchExchange contract auctioneer')
   }
 
-
   it('not auctioneer can\'t change params', async () => {
     const params1 = await getAndPrintExchangeParams()
   
@@ -109,7 +108,7 @@ contract('DutchExchange updating exchange params', (accounts) => {
     const params1 = await getAndPrintExchangeParams()
 
     await assertIsAuctioneer(master)
-    console.log(params2.ethUSDOracle)
+    logger(`initiating oracle address update to ${params2.ethUSDOracle}`)
     await dx.initiateEthUsdOracleUpdate(params2.ethUSDOracle, { from: master })
     await assertRejects(dx.updateEthUSDOracle({ from: master }), 'to early to change oracle interface')
   })


### PR DESCRIPTION
Fixes solium linter issues, mostly formatting.

Disables rules:
* security/no-inline-assembly - usage of assembly
* security/no-assign-params - assigning to function parameter

@anxolin , let me know if you want _security/no-assign-params_ back on and to instead add temp vars. Or make it into a warning.

This still leaves unaddressed:
* Avoid using 'now' and 'block.timestamp'
* Constant names 'symbol', 'name', 'decimals' doesn't follow the UPPER_CASE notation
* Code contains empty block
and some others.

Those are warnings that don't prevent tests from running. They of course also can be disabled if needed.