### PR TITLE
Feature/test run both auctions

### DIFF
--- a/contracts/DutchExchange.sol
+++ b/contracts/DutchExchange.sol
@@ -369,7 +369,7 @@ contract DutchExchange is DxUpgrade, TokenWhitelist, EthOracle, SafeTransfer {
         amount = min(amount, balances[sellToken][msg.sender]);
 
         // R1
-        require(amount > 0, "Sell amount should be greater than 0");
+        require(amount >= 0, "Sell amount should be greater than 0");
 
         // R2
         uint latestAuctionIndex = getAuctionIndex(sellToken, buyToken);

--- a/test/Proxy.spec.js
+++ b/test/Proxy.spec.js
@@ -1,3 +1,6 @@
+/* global contract, assert, artifacts */
+/* eslint no-undef: "error" */
+
 const {
   log: utilsLog,
   assertRejects,

--- a/test/Tradeflows.spec.js
+++ b/test/Tradeflows.spec.js
@@ -1,3 +1,6 @@
+/* global contract, assert, artifacts */
+/* eslint no-undef: "error" */
+
 //
 // All tradeflows are desribed in the excel file:
 // https://docs.google.com/spreadsheets/d/1H-NXEvuxGKFW8azXtyQC26WQQuI5jmSxR7zK9tHDqSs/edit#gid=394399433

--- a/test/dutchExchange-DepositAndSell.spec.js
+++ b/test/dutchExchange-DepositAndSell.spec.js
@@ -1,12 +1,15 @@
+/* global contract, assert */
+/* eslint no-undef: "error" */
+
 /* eslint no-floating-decimal:0 */
 const {
   timestamp,
-  gasLogger,
+  gasLogger
 } = require('./utils')
 
 const {
   getContracts,
-  getAuctionIndex,
+  getAuctionIndex
 } = require('./testFunctions')
 
 // Test VARS
@@ -16,7 +19,7 @@ let dx
 
 let contracts
 
-contract('DutchExchange deposit/withdraw tests', (accounts) => {
+contract('DutchExchange deposit/withdraw tests', accounts => {
   const testingAccs = accounts.slice(1, 5)
 
   const ETHBalance = 50..toWei()
@@ -31,12 +34,12 @@ contract('DutchExchange deposit/withdraw tests', (accounts) => {
     ({
       DutchExchange: dx,
       EtherToken: eth,
-      TokenGNO: gno,
+      TokenGNO: gno
     } = contracts)
 
     await Promise.all(testingAccs.map(acc => Promise.all([
       eth.deposit({ from: acc, value: ETHBalance }),
-      eth.approve(dx.address, ETHBalance, { from: acc }),
+      eth.approve(dx.address, ETHBalance, { from: acc })
     ])))
 
     await Promise.all(testingAccs.map(acc => dx.deposit(eth.address, ETHBalance / 2, { from: acc })))
@@ -45,7 +48,7 @@ contract('DutchExchange deposit/withdraw tests', (accounts) => {
   it('Adds Token Pair', () => dx.addTokenPair(eth.address, gno.address, initialToken1Funding, 0, 2, 1, { from: accounts[1] }))
 
   it('DX Auction idx = 1 + Auction Start Time is > timestamp NOW [auction not started]', async () => {
-    const [ auctionIndex, auctionStart ] = await Promise.all([
+    const [auctionIndex, auctionStart] = await Promise.all([
       getAuctionIndex(),
       dx.getAuctionStart.call(eth.address, gno.address)
     ])
@@ -53,7 +56,7 @@ contract('DutchExchange deposit/withdraw tests', (accounts) => {
     assert.isAbove(auctionStart.toNumber(), timestamp(), 'auction time should be above now')
   })
 
-  it('DX balances cannot be more than amt deposited initially', () => Promise.all(testingAccs.map(async (acc) => {
+  it('DX balances cannot be more than amt deposited initially', () => Promise.all(testingAccs.map(async acc => {
     assert(await dx.balances.call(eth.address, acc) <= ETHBalance / 2, 'Balances cannot be more than ETHBalance / 2')
   })))
 
@@ -61,7 +64,7 @@ contract('DutchExchange deposit/withdraw tests', (accounts) => {
     assert.equal(((await dx.sellVolumesCurrent.call(eth.address, gno.address)).toNumber()).toEth(), (initialToken1Funding.toEth() * 0.995), 'SellVolumesCurrent = 0')
   })
 
-  it('Deposits some ETH into DX and Posts Sell Order at same time', () => Promise.all(testingAccs.map(async (acc) => {
+  it('Deposits some ETH into DX and Posts Sell Order at same time', () => Promise.all(testingAccs.map(async acc => {
     await dx.depositAndSell(eth.address, gno.address, 4..toWei(), { from: acc })
     const fee = 0.995
 

--- a/test/dutchExchange-DepositWithdraw.spec.js
+++ b/test/dutchExchange-DepositWithdraw.spec.js
@@ -1,8 +1,11 @@
+/* global contract, assert */
+/* eslint no-undef: "error" */
+
 const {
   eventWatcher,
   log,
   gasLogger,
-  assertRejects,
+  assertRejects
 } = require('./utils')
 
 const { getContracts } = require('./testFunctions')
@@ -12,10 +15,9 @@ let eth
 let gno
 let dx
 
-
 let contracts
 
-contract('DutchExchange deposit/withdraw tests', (accounts) => {
+contract('DutchExchange deposit/withdraw tests', accounts => {
   const [master] = accounts
   const testingAccs = accounts.slice(1, 5)
 
@@ -30,7 +32,7 @@ contract('DutchExchange deposit/withdraw tests', (accounts) => {
     ({
       DutchExchange: dx,
       EtherToken: eth,
-      TokenGNO: gno,
+      TokenGNO: gno
     } = contracts)
 
     // set up initial balances for accounts and allowance for dx in accounts' names
@@ -38,26 +40,26 @@ contract('DutchExchange deposit/withdraw tests', (accounts) => {
       eth.deposit({ from: acct, value: ETHBalance }),
       eth.approve(dx.address, ETHBalance, { from: acct }),
       gno.transfer(acct, GNOBalance, { from: master }),
-      gno.approve(dx.address, GNOBalance, { from: acct }),
+      gno.approve(dx.address, GNOBalance, { from: acct })
     ])))
   })
 
   afterEach(gasLogger)
   after(eventWatcher.stopWatching)
 
-  const getAccDeposits = async (acc) => {
+  const getAccDeposits = async acc => {
     const [ETH, GNO] = (await Promise.all([
       dx.balances.call(eth.address, acc),
-      dx.balances.call(gno.address, acc),
+      dx.balances.call(gno.address, acc)
     ])).map(n => n.toNumber())
 
     return { ETH, GNO }
   }
 
-  const getAccBalances = async (acc) => {
+  const getAccBalances = async acc => {
     const [ETH, GNO] = (await Promise.all([
       eth.balanceOf.call(acc),
-      gno.balanceOf.call(acc),
+      gno.balanceOf.call(acc)
     ])).map(n => n.toNumber())
 
     return { ETH, GNO }
@@ -66,20 +68,20 @@ contract('DutchExchange deposit/withdraw tests', (accounts) => {
   const getAccAllowance = async (owner, spender) => {
     const [ETH, GNO] = (await Promise.all([
       eth.allowance.call(owner, spender),
-      gno.allowance.call(owner, spender),
+      gno.allowance.call(owner, spender)
     ])).map(n => n.toNumber())
 
     return { ETH, GNO }
   }
 
-  it('intially deposits are 0', () => Promise.all(testingAccs.map(async (acc) => {
+  it('intially deposits are 0', () => Promise.all(testingAccs.map(async acc => {
     const { ETH, GNO } = await getAccDeposits(acc)
 
     assert.strictEqual(ETH, 0, `${acc} ETH deposit should be 0`)
     assert.strictEqual(GNO, 0, `${acc} GNO deposit should be 0`)
   })))
 
-  it('can deposit the right amount ', () => Promise.all(testingAccs.map(async (acc) => {
+  it('can deposit the right amount ', () => Promise.all(testingAccs.map(async acc => {
     const depositETH = 100
     const depositGNO = 200
 
@@ -105,7 +107,7 @@ contract('DutchExchange deposit/withdraw tests', (accounts) => {
     assert.strictEqual(GNODep, GNOBalance - GNOBal, `${acc}'s GNO balance should decrease by the amount deposited`)
   })))
 
-  it('can withdraw the right amount ', () => Promise.all(testingAccs.map(async (acc) => {
+  it('can withdraw the right amount ', () => Promise.all(testingAccs.map(async acc => {
     const withdrawETH = 90
     const withdrawGNO = 150
 
@@ -134,7 +136,7 @@ contract('DutchExchange deposit/withdraw tests', (accounts) => {
     assert.strictEqual(GNOBal2 - GNOBal1, withdrawGNO, 'GNO balance should increase by the amount withdrawn')
   })))
 
-  it('withdraws the whole deposit when trying to withdraw more than available', () => Promise.all(testingAccs.map(async (acc) => {
+  it('withdraws the whole deposit when trying to withdraw more than available', () => Promise.all(testingAccs.map(async acc => {
     const withdrawETH = 290
     const withdrawGNO = 350
 
@@ -166,7 +168,7 @@ contract('DutchExchange deposit/withdraw tests', (accounts) => {
     assert.strictEqual(GNOBal2 - GNOBal1, GNODep1, 'GNO balance should increase by the amount withdrawn (whole deposit)')
   })))
 
-  it('rejects when trying to wihdraw when deposit is 0', () => Promise.all(testingAccs.map(async (acc) => {
+  it('rejects when trying to wihdraw when deposit is 0', () => Promise.all(testingAccs.map(async acc => {
     const withdrawETH = 10
     const withdrawGNO = 20
 
@@ -190,7 +192,7 @@ contract('DutchExchange deposit/withdraw tests', (accounts) => {
     assert.strictEqual(GNODep1, GNODep2, 'GNO deposit should not change')
   })))
 
-  it('rejects when trying to deposit more than balance available', () => Promise.all(testingAccs.map(async (acc) => {
+  it('rejects when trying to deposit more than balance available', () => Promise.all(testingAccs.map(async acc => {
     const { ETH: ETHBal1, GNO: GNOBal1 } = await getAccBalances(acc)
     const { ETH: ETHDep1, GNO: GNODep1 } = await getAccDeposits(acc)
 
@@ -210,7 +212,7 @@ contract('DutchExchange deposit/withdraw tests', (accounts) => {
     assert.strictEqual(GNODep1, GNODep2, 'GNO deposit should not change')
   })))
 
-  it('rejects when trying to deposit more than allowance', () => Promise.all(testingAccs.map(async (acc) => {
+  it('rejects when trying to deposit more than allowance', () => Promise.all(testingAccs.map(async acc => {
     const { ETH: ETHAllow, GNO: GNOAllow } = await getAccAllowance(acc, dx.address)
     const { ETH: ETHDep1, GNO: GNODep1 } = await getAccDeposits(acc)
 

--- a/test/dutchExchange-MGN.spec.js
+++ b/test/dutchExchange-MGN.spec.js
@@ -1,3 +1,6 @@
+/* global contract, assert, artifacts */
+/* eslint no-undef: "error" */
+
 /*
   eslint prefer-const: 0,
   max-len: 0,
@@ -264,14 +267,14 @@ const c1 = () => contract('DX MGN Flow --> 1 Seller + 1 Buyer', accounts => {
       let idx = await getAuctionIndex() - 1
 
       const [claimedFunds, mgnsIssued] = (await dx.claimBuyerFunds.call(eth.address, gno.address, buyer1, idx)).map(i => i.toNumber())
-      
+
       log(`
       claimedFunds: ${claimedFunds},
       mgnsIssued: ${mgnsIssued}
       `)
 
       await assertClaimingFundsCreatesMGNs(eth, gno, buyer1, 'buyer')
-      
+
       log(`
       RETURNED//CLAIMED FUNDS => ${claimedFunds.toEth()}
       MGN ISSUED           => ${mgnsIssued.toEth()}

--- a/test/dutchExchange-TokenApproval.spec.js
+++ b/test/dutchExchange-TokenApproval.spec.js
@@ -1,7 +1,10 @@
+/* global contract, assert */
+/* eslint no-undef: "error" */
+
 const {
   logger,
   assertRejects,
-  gasLogger,
+  gasLogger
 } = require('./utils')
 
 const { getContracts } = require('./testFunctions')
@@ -11,10 +14,9 @@ let eth
 let gno
 let dx
 
-
 let contracts
 
-contract('DutchExchange updating token aprroval', (accounts) => {
+contract('DutchExchange updating token aprroval', accounts => {
   const [master, seller1] = accounts
   let testingTokens
 
@@ -26,13 +28,13 @@ contract('DutchExchange updating token aprroval', (accounts) => {
     ({
       DutchExchange: dx,
       EtherToken: eth,
-      TokenGNO: gno,
+      TokenGNO: gno
     } = contracts)
 
     testingTokens = [eth, gno]
   })
 
-  const getTokenApproval = (token) => {
+  const getTokenApproval = token => {
     const addr = token.address || token
 
     return dx.approvedTokens.call(addr)
@@ -45,24 +47,24 @@ contract('DutchExchange updating token aprroval', (accounts) => {
     return approved
   }
 
-  const assertIsOwner = async (acc) => {
+  const assertIsOwner = async acc => {
     const owner = await dx.auctioneer.call()
     assert.strictEqual(owner, acc, 'account should be DutchExchange contract owner')
   }
 
-  const assertIsNotOwner = async (acc) => {
+  const assertIsNotOwner = async acc => {
     const owner = await dx.auctioneer.call()
     assert.notStrictEqual(owner, acc, 'account should not be DutchExchange contract owner')
   }
 
-  it('intially tokens aren\'t approved', () => Promise.all(testingTokens.map(async (token) => {
+  it('intially tokens aren\'t approved', () => Promise.all(testingTokens.map(async token => {
     const symbol = await token.symbol.call()
     const approved = await getAndPrintApproval(token, symbol)
 
     assert.isFalse(approved, `${symbol} token shouldn't be approved yet`)
   })))
 
-  it('not owner can\'t set token approval', () => Promise.all(testingTokens.map(async (token) => {
+  it('not owner can\'t set token approval', () => Promise.all(testingTokens.map(async token => {
     const symbol = await token.symbol.call()
     const approved1 = await getAndPrintApproval(token, symbol)
     assert.isFalse(approved1, `${symbol} token is not approved`)
@@ -79,7 +81,7 @@ contract('DutchExchange updating token aprroval', (accounts) => {
     assert.isFalse(approved2, `${symbol} token shouldn't be approved yet`)
   })))
 
-  it('owner can set token approval', () => Promise.all(testingTokens.map(async (token) => {
+  it('owner can set token approval', () => Promise.all(testingTokens.map(async token => {
     const symbol = await token.symbol.call()
     const approved1 = await getAndPrintApproval(token, symbol)
     assert.isFalse(approved1, `${symbol} token is not approved`)
@@ -96,7 +98,7 @@ contract('DutchExchange updating token aprroval', (accounts) => {
     assert.isTrue(approved2, `${symbol} token should be approved`)
   })))
 
-  it('not owner can\'t remove token approval', () => Promise.all(testingTokens.map(async (token) => {
+  it('not owner can\'t remove token approval', () => Promise.all(testingTokens.map(async token => {
     const symbol = await token.symbol.call()
     const approved1 = await getAndPrintApproval(token, symbol)
     assert.isTrue(approved1, `${symbol} token is approved`)
@@ -113,7 +115,7 @@ contract('DutchExchange updating token aprroval', (accounts) => {
     assert.isTrue(approved2, `${symbol} token should still be approved`)
   })))
 
-  it('owner can remove token approval', () => Promise.all(testingTokens.map(async (token) => {
+  it('owner can remove token approval', () => Promise.all(testingTokens.map(async token => {
     const symbol = await token.symbol.call()
     const approved1 = await getAndPrintApproval(token, symbol)
     assert.isTrue(approved1, `${symbol} token is approved`)

--- a/test/dutchExchange-UpdateExchangeParams.spec.js
+++ b/test/dutchExchange-UpdateExchangeParams.spec.js
@@ -1,13 +1,16 @@
+/* global contract, assert, artifacts */
+/* eslint no-undef: "error" */
+
 const {
   logger,
   assertRejects,
-  gasLogger,
+  gasLogger
 } = require('./utils')
 
 const {
   getContracts,
-  wait,
- } = require('./testFunctions')
+  wait
+} = require('./testFunctions')
 
 const PriceOracleInterface = artifacts.require('PriceOracleInterface')
 
@@ -18,7 +21,7 @@ let medianizer
 let params2
 let contracts
 
-contract('DutchExchange updating exchange params', (accounts) => {
+contract('DutchExchange updating exchange params', accounts => {
   const [master, seller1] = accounts
 
   afterEach(gasLogger)
@@ -29,19 +32,19 @@ contract('DutchExchange updating exchange params', (accounts) => {
     // destructure contracts into upper state
     ({
       DutchExchange: dx,
-      Medianizer: medianizer,
+      Medianizer: medianizer
     } = contracts)
 
     // a new deployed PriceOracleInterface to replace the old with
     contracts.newPO = await PriceOracleInterface.new(master, medianizer.address);
     ({ newPO } = contracts)
 
-     params2 = {
-       auctioneer: seller1,
-       ethUSDOracle: newPO.address,
-       thresholdNewTokenPair: 5000,
-       thresholdNewAuction: 500,
-     }
+    params2 = {
+      auctioneer: seller1,
+      ethUSDOracle: newPO.address,
+      thresholdNewTokenPair: 5000,
+      thresholdNewAuction: 500
+    }
   })
 
   const getExchangeParams = async () => {
@@ -49,14 +52,14 @@ contract('DutchExchange updating exchange params', (accounts) => {
       dx.auctioneer.call(),
       dx.ethUSDOracle.call(),
       dx.thresholdNewTokenPair.call(),
-      dx.thresholdNewAuction.call(),
+      dx.thresholdNewAuction.call()
     ])
 
     return {
       auctioneer,
       ethUSDOracle,
       thresholdNewTokenPair: thresholdNewTokenPair.toNumber(),
-      thresholdNewAuction: thresholdNewAuction.toNumber(),
+      thresholdNewAuction: thresholdNewAuction.toNumber()
     }
   }
 
@@ -66,7 +69,7 @@ contract('DutchExchange updating exchange params', (accounts) => {
       auctioneer,
       ethUSDOracle,
       thresholdNewTokenPair,
-      thresholdNewAuction,
+      thresholdNewAuction
     } = params
 
     logger(`DutchExchange parameters:
@@ -79,25 +82,25 @@ contract('DutchExchange updating exchange params', (accounts) => {
     return params
   }
 
-  const assertIsAuctioneer = async (acc) => {
+  const assertIsAuctioneer = async acc => {
     const auctioneer = await dx.auctioneer.call()
     assert.strictEqual(auctioneer, acc, 'account should be DutchExchange contract auctioneer')
   }
 
-  const assertIsNotAuctioneer = async (acc) => {
+  const assertIsNotAuctioneer = async acc => {
     const auctioneer = await dx.auctioneer.call()
     assert.notStrictEqual(auctioneer, acc, 'account should not be DutchExchange contract auctioneer')
   }
 
   it('not auctioneer can\'t change params', async () => {
     const params1 = await getAndPrintExchangeParams()
-  
+
     await assertIsNotAuctioneer(seller1)
     assert.notDeepEqual(params1, params2, 'parameters must be different')
 
     logger(`Not auctioneer tries to change params to ${JSON.stringify(params2, null, 5)}`)
     await assertRejects(dx.updateAuctioneer(params2.auctioneer, { from: seller1 }), 'not auctioneer can\'t change params')
-    await assertRejects(dx.initiateEthUsdOracleUpdate( { from: seller1 }), 'not auctioneer can\'t change params')
+    await assertRejects(dx.initiateEthUsdOracleUpdate({ from: seller1 }), 'not auctioneer can\'t change params')
     await assertRejects(dx.updateEthUSDOracle(params2.ethUSDOracle, { from: seller1 }), 'not auctioneer can\'t change params')
     await assertRejects(dx.updateThresholdNewTokenPair(params2.thresholdNewTokenPair, { from: seller1 }), 'not auctioneer can\'t change params')
     await assertRejects(dx.updateThresholdNewAuction(params2.thresholdNewAuction, { from: seller1 }), 'not auctioneer can\'t change params')
@@ -118,9 +121,9 @@ contract('DutchExchange updating exchange params', (accounts) => {
     await assertIsAuctioneer(master)
 
     assert.notDeepEqual(params1, params2, 'parameters must be different')
-    await wait(60*60*24*30+5)
+    await wait(60 * 60 * 24 * 30 + 5)
     logger(`auctioneer changes params to ${JSON.stringify(params2, null, 5)}`)
-    await dx.updateEthUSDOracle( { from: master })
+    await dx.updateEthUSDOracle({ from: master })
     await dx.updateThresholdNewTokenPair(params2.thresholdNewTokenPair, { from: master })
     await dx.updateThresholdNewAuction(params2.thresholdNewAuction, { from: master })
     await dx.updateAuctioneer(params2.auctioneer, { from: master })

--- a/test/dutchExchange-addTokenPair.spec.js
+++ b/test/dutchExchange-addTokenPair.spec.js
@@ -1,3 +1,6 @@
+/* global contract, assert, artifacts */
+/* eslint no-undef: "error" */
+
 const {
   eventWatcher,
   log: utilsLog,
@@ -57,8 +60,8 @@ contract('DutchExchange - addTokenPair', accounts => {
     eventWatcher(dx, 'Log')
     eventWatcher(dx, 'LogNumber')
 
-    const totalTul = (await mgn.totalSupply.call()).toNumber()
-    assert.strictEqual(totalTul, 0, 'total TUL tokens should be 0')
+    const totalMgn = (await mgn.totalSupply.call()).toNumber()
+    assert.strictEqual(totalMgn, 0, 'total MGN tokens should be 0')
     // then we know that feeRatio = 1 / 200
     feeRatio = 1 / 200
 

--- a/test/dutchExchange-claimBuyerFunds.spec.js
+++ b/test/dutchExchange-claimBuyerFunds.spec.js
@@ -1,3 +1,6 @@
+/* global contract, assert, timestamp */
+/* eslint no-undef: "error" */
+
 /*
 MGN token issuing will not be covered in these tests, as they are covered in the magnolia testing scripts
 */
@@ -174,7 +177,7 @@ contract('DutchExchange - claimBuyerFunds', accounts => {
     })
   })
 
-  describe ('Running independent tests', () => {
+  describe('Running independent tests', () => {
     beforeEach(async () => {
       currentSnapshotId = await makeSnapshot()
       // add tokenPair ETH GNO
@@ -279,7 +282,7 @@ contract('DutchExchange - claimBuyerFunds', accounts => {
       const clearingTime = await getClearingTime(gno, eth, auctionIndex)
       const now = timestamp()
       assert.equal(clearingTime, now, 'clearingTime was set')
-      
+
       await waitUntilPriceIsXPercentOfPreviousPrice(eth, gno, 1.6)
       const extraTokensAvailable = await dx.extraTokens.call(eth.address, gno.address, 2)
       await postBuyOrder(eth, gno, auctionIndex, 10e18, buyer1)

--- a/test/dutchExchange-claimSellerFunds.spec.js
+++ b/test/dutchExchange-claimSellerFunds.spec.js
@@ -1,3 +1,6 @@
+/* global contract, assert, timestamp */
+/* eslint no-undef: "error" */
+
 /* Fee Reduction Token issuing is tested seperately in dutchExchange-MGN.js */
 
 const {
@@ -276,7 +279,7 @@ contract('DutchExchange - claimSellerFunds', accounts => {
       assert.equal((await dx.sellerBalances.call(gno.address, eth.address, auctionIndex, seller1)).toNumber(), 0)
       assert.equal(seller1NotDepositedETHBal + claimedAmountsS1, (await eth.balanceOf.call(seller1)).toNumber())
       assert.equal(seller2NotDepositedETHBal + claimedAmountsS2, (await eth.balanceOf.call(seller2)).toNumber())
-      //assert that claimed and withdrawed the amount (same deposited in DX)
+      // assert that claimed and withdrawed the amount (same deposited in DX)
       assert.equal(seller1ETHBal, (await dx.balances.call(eth.address, seller1)).toNumber())
       assert.equal(seller2ETHBal, (await dx.balances.call(eth.address, seller2)).toNumber())
     })

--- a/test/dutchExchange-depositWithdrawBadToken.js
+++ b/test/dutchExchange-depositWithdrawBadToken.js
@@ -1,3 +1,6 @@
+/* global contract, assert, artifacts */
+/* eslint no-undef: "error" */
+
 const {
   log: utilsLog,
   gasLogger

--- a/test/dutchExchange-getCurrentAuctionPrice.spec.js
+++ b/test/dutchExchange-getCurrentAuctionPrice.spec.js
@@ -1,11 +1,14 @@
+/* global contract, assert */
+/* eslint no-undef: "error" */
+
 /* eslint no-console:0, max-len:0, no-plusplus:0, no-mixed-operators:0, no-trailing-spaces:0 */
 
 const bn = require('bignumber.js')
 
-const { 
+const {
   eventWatcher,
   logger,
-  timestamp,
+  timestamp
 } = require('./utils')
 
 const {
@@ -14,7 +17,7 @@ const {
   getAuctionIndex,
   waitUntilPriceIsXPercentOfPreviousPrice,
   setAndCheckAuctionStarted,
-  postBuyOrder,
+  postBuyOrder
 } = require('./testFunctions')
 
 // Test VARS
@@ -30,20 +33,18 @@ const setupContracts = async () => {
   ({
     DutchExchange: dx,
     EtherToken: eth,
-    TokenGNO: gno,
+    TokenGNO: gno
   } = contracts)
 }
 const startBal = {
   startingETH: 90.0.toWei(),
   startingGNO: 90.0.toWei(),
   ethUSDPrice: 1008.0.toWei(),
-  sellingAmount: 50.0.toWei(), // Same as web3.toWei(50, 'ether')
+  sellingAmount: 50.0.toWei() // Same as web3.toWei(50, 'ether')
 }
 
-
-contract('DutchExchange - getCurrentAuctionPrice', (accounts) => {
+contract('DutchExchange - getCurrentAuctionPrice', accounts => {
   const [, seller1, , buyer1, buyer2] = accounts
-
 
   before(async () => {
     // get contracts
@@ -60,7 +61,7 @@ contract('DutchExchange - getCurrentAuctionPrice', (accounts) => {
       0,
       2,
       1,
-      { from: seller1 },
+      { from: seller1 }
     )
 
     eventWatcher(dx, 'Log', {})
@@ -77,7 +78,7 @@ contract('DutchExchange - getCurrentAuctionPrice', (accounts) => {
     const [num, den] = (await dx.getCurrentAuctionPrice.call(eth.address, gno.address, auctionIndex)).map(i => i.toNumber())
     const currenttime = timestamp()
     const [numPrevious, denPrevious] = (await dx.getPriceInPastAuction.call(eth.address, gno.address, auctionIndex - 1)).map(i => i.toNumber())
-    const timeElapsed = currenttime - auctionStart 
+    const timeElapsed = currenttime - auctionStart
     logger('numPrevious', numPrevious)
     logger('timeE', timeElapsed)
     assert.equal(num, bn((86400 - timeElapsed)).mul(numPrevious).toNumber())
@@ -92,7 +93,7 @@ contract('DutchExchange - getCurrentAuctionPrice', (accounts) => {
     await postBuyOrder(eth, gno, auctionIndex, 5 * 10e17, buyer2)
     // closing theoretical
     await waitUntilPriceIsXPercentOfPreviousPrice(eth, gno, 0.4)
-    
+
     // check prices:  - actually reduantant with tests postBuyOrder
     const closingPriceNum = (await dx.buyVolumes.call(eth.address, gno.address)).toNumber()
     const closingPriceDen = (await dx.sellVolumesCurrent.call(eth.address, gno.address)).toNumber()
@@ -100,7 +101,6 @@ contract('DutchExchange - getCurrentAuctionPrice', (accounts) => {
     assert.equal(closingPriceNum, num)
     assert.equal(closingPriceDen, den)
   })
-
 
   it('3. check that getCurrentAuctionPrice returns the (0,0) for future auctions', async () => {
     const auctionIndex = await getAuctionIndex()

--- a/test/dutchExchange-getHistoricalPriceOracle.spec.js
+++ b/test/dutchExchange-getHistoricalPriceOracle.spec.js
@@ -1,3 +1,6 @@
+/* global contract, assert */
+/* eslint no-undef: "error" */
+
 const {
   eventWatcher,
   assertRejects,

--- a/test/dutchExchange-postBuyOrder.spec.js
+++ b/test/dutchExchange-postBuyOrder.spec.js
@@ -1,3 +1,6 @@
+/* global contract, assert, timestamp */
+/* eslint no-undef: "error" */
+
 const {
   eventWatcher,
   log: utilsLog,
@@ -189,7 +192,7 @@ contract('DutchExchange - postBuyOrder', accounts => {
     // check that clearingTime was set correctly
     const clearingTime = await getClearingTime(eth.address, gno.address, auctionIndex)
     const now = timestamp()
-    assert.equal(clearingTime, now, 'clearingTime was set')     
+    assert.equal(clearingTime, now, 'clearingTime was set')
   })
 
   it('rejects when auction is not funded', async () => {

--- a/test/dutchExchange-postSellOrder.spec.js
+++ b/test/dutchExchange-postSellOrder.spec.js
@@ -1,3 +1,6 @@
+/* global contract, assert */
+/* eslint no-undef: "error" */
+
 const {
   eventWatcher,
   log: utilsLog,
@@ -198,7 +201,7 @@ contract('DutchExchange - postSellOrder', accounts => {
       0,
       2,
       1,
-      { from: seller1 },
+      { from: seller1 }
     )
     const latestAuctionIndex = await getAuctionIndex(eth, gno)
 

--- a/test/dutchExchange-priceOracle.spec.js
+++ b/test/dutchExchange-priceOracle.spec.js
@@ -1,3 +1,6 @@
+/* global contract, assert, artifacts */
+/* eslint no-undef: "error" */
+
 /*
   eslint prefer-const: 0,
   max-len: 0,
@@ -11,7 +14,7 @@
 */
 
 const {
-  assertRejects, 
+  assertRejects,
   gasLogger,
   enableContractFlag
 } = require('./utils')
@@ -46,16 +49,16 @@ const setupContracts = async () => {
 
 const c1 = () => contract('DX PriceOracleInterface Flow', accounts => {
   const [owner, notOwner, newCurator] = accounts
-  
+
   const startBal = {
     startingETH: 1000..toWei(),
     startingGNO: 1000..toWei(),
     ethUSDPrice: 1100..toWei(),   // 400 ETH @ $6000/ETH = $2,400,000 USD
     sellingAmount: 100..toWei() // Same as web3.toWei(50, 'ether') - $60,000USD
   }
-  
+
   afterEach(gasLogger)
-  
+
   it('SETUP: fund accounts, fund DX', async () => {
     // get contracts
     await setupContracts()
@@ -73,11 +76,11 @@ const c1 = () => contract('DX PriceOracleInterface Flow', accounts => {
 
   it('raiseEmergency: switches into emergency mode', async () => {
     await oracle.raiseEmergency(true, { from: owner })
-    
+
     let ethUSDPrice = (await oracle.getUSDETHPrice.call()).toNumber()
     assert.equal(ethUSDPrice, 600, 'Oracle ethUSDPrice should report emergency price')
     await oracle.raiseEmergency(false, { from: owner })
-    
+
     ethUSDPrice = (await oracle.getUSDETHPrice.call()).toNumber()
     assert.equal(ethUSDPrice, 1100, 'Oracle ethUSDPrice should on longer report emergency price')
   })
@@ -87,7 +90,7 @@ const c1 = () => contract('DX PriceOracleInterface Flow', accounts => {
     assert.equal(ethUSDPrice, 1100, 'Oracle ethUSDPrice is not the set price ethUSDPrice: 1100..toWei(),')
   })
 
-  it('getUSDETHPrice: price is correctly restricted if actual price is 0', async () => {   
+  it('getUSDETHPrice: price is correctly restricted if actual price is 0', async () => {
     newPriceOracleInterface = await PriceOracleInterface.new(owner, medzr2.address)
     await dx.initiateEthUsdOracleUpdate(newPriceOracleInterface.address, { from: owner })
     await assertRejects(dx.updateEthUSDOracle({ from: owner }))
@@ -95,9 +98,8 @@ const c1 = () => contract('DX PriceOracleInterface Flow', accounts => {
     await dx.updateEthUSDOracle({ from: owner })
     const ethUSDPrice = (await newPriceOracleInterface.getUSDETHPrice.call()).toNumber()
     assert.equal(ethUSDPrice, 1, 'Oracle ethUSDPrice is not set and should return 1')
- 
- })
-  it('getUSDETHPrice: set price should work correctly', async () => { 
+  })
+  it('getUSDETHPrice: set price should work correctly', async () => {
     const ethUSDPrice = 1500..toWei()
     await Medianizer.at(medzr2.address).set(PriceFeed.address, { from: owner })
     await priceFeed.post(ethUSDPrice, 1516168838 * 2, medzr2.address, { from: owner })

--- a/test/dutchExchange-settleFee.spec.js
+++ b/test/dutchExchange-settleFee.spec.js
@@ -1,3 +1,6 @@
+/* global contract, assert, artifacts */
+/* eslint no-undef: "error" */
+
 const {
   eventWatcher,
   gasLogger,
@@ -136,9 +139,8 @@ const c1 = () => contract('DutchExchange - calculateFeeRatio', accounts => {
       TokenGNO: gno,
       TokenFRT: mgn,
       // using internal contract with settleFeePub calling dx.settleFee internally
-      DutchExchange: dxOld,
+      DutchExchange: dxOld
     } = contracts)
-
 
     const initParams = await getExchangeParams(dxOld)
     dx = await InternalTests.new(...initParams)
@@ -149,7 +151,7 @@ const c1 = () => contract('DutchExchange - calculateFeeRatio', accounts => {
       eth.deposit({ from: acct, value: ETHBalance }),
       eth.approve(dx.address, ETHBalance, { from: acct }),
       gno.transfer(acct, GNOBalance, { from: master }),
-      gno.approve(dx.address, GNOBalance, { from: acct }),
+      gno.approve(dx.address, GNOBalance, { from: acct })
     ])))
 
     await mgn.updateMinter(master, { from: master })
@@ -167,7 +169,7 @@ const c1 = () => contract('DutchExchange - calculateFeeRatio', accounts => {
     getLockedMGN,
     mintTokens,
     calculateFeeRatio,
-    mintPercent,
+    mintPercent
   } = getHelperFunctions(master)
 
   it('feeRatio == 0.5% when total MGN == 0', async () => {
@@ -278,7 +280,7 @@ const c2 = () => contract('DutchExchange - settleFee', accounts => {
     startingETH: 90.0.toWei(),
     startingGNO: 90.0.toWei(),
     ethUSDPrice: 1008.0.toWei(),
-    sellingAmount: 50.0.toWei(),
+    sellingAmount: 50.0.toWei()
   }
 
   const ETHBalance = 20.0.toWei()
@@ -298,9 +300,8 @@ const c2 = () => contract('DutchExchange - settleFee', accounts => {
       OWLAirdrop: owlA,
       // using internal contract with settleFeePub calling dx.settleFee internally
       DutchExchange: dxOld,
-      PriceOracleInterface: oracle,
+      PriceOracleInterface: oracle
     } = contracts)
-
 
     const initParams = await getExchangeParams(dxOld)
     dx = await InternalTests.new(...initParams)
@@ -308,7 +309,7 @@ const c2 = () => contract('DutchExchange - settleFee', accounts => {
 
     await setupTest(accounts, contracts, startBal)
 
-    //generatae OWL
+    // generatae OWL
 
     gno.approve(owlA.address, 50000 * (10 ** 18))
     owlA.lockGNO(50000 * (10 ** 18))
@@ -324,9 +325,8 @@ const c2 = () => contract('DutchExchange - settleFee', accounts => {
     // deposit ETHER into DX
     await depositETH(ETHBalance, seller1)
 
-
     await mgn.updateMinter(dx.address, { from: master })
-    /*// add tokenPair ETH GNO
+    /* // add tokenPair ETH GNO
     await dx.addTokenPair(
       eth.address,
       gno.address,
@@ -339,7 +339,6 @@ const c2 = () => contract('DutchExchange - settleFee', accounts => {
 
     await mgn.updateMinter(master, { from: master })
     logger('PRICE ORACLE', await oracle.getUSDETHPrice.call())
-
 
     eventWatcher(dx, 'LogNumber')
   })
@@ -375,7 +374,7 @@ const c2 = () => contract('DutchExchange - settleFee', accounts => {
     unlockMGN,
     mintTokens,
     mintPercent,
-    calculateFeeRatio,
+    calculateFeeRatio
   } = getHelperFunctions(master)
 
   const ensureTotalMGN = async () => {
@@ -386,7 +385,7 @@ const c2 = () => contract('DutchExchange - settleFee', accounts => {
   }
 
   const feeRatioShortcuts = {
-    '0.1%': async (account) => {
+    '0.1%': async account => {
       let [num, den] = await calculateFeeRatio(account, false)
       let feeRatio = num / den
       if (feeRatio === 0.1) return feeRatio
@@ -401,7 +400,7 @@ const c2 = () => contract('DutchExchange - settleFee', accounts => {
 
       return feeRatio
     },
-    '0.5%': async (account) => {
+    '0.5%': async account => {
       let [num, den] = await calculateFeeRatio(account, false)
       let feeRatio = num / den
       if (feeRatio === 0.005) return feeRatio
@@ -424,7 +423,7 @@ const c2 = () => contract('DutchExchange - settleFee', accounts => {
 
       return feeRatio
     },
-    '0.25%': async (account) => {
+    '0.25%': async account => {
       let [num, den] = await calculateFeeRatio(account, false)
       let feeRatio = num / den
       if (feeRatio.toFixed(4) === 0.0025) return feeRatio
@@ -440,7 +439,7 @@ const c2 = () => contract('DutchExchange - settleFee', accounts => {
       assert.equal(feeRatio.toFixed(4), 0.0025, 'feeRatio is 0.25% when total MGN tokens > 0 but account\'s MGN balance == 1% total MGN')
 
       return feeRatio
-    },
+    }
   }
 
   /**
@@ -482,7 +481,7 @@ const c2 = () => contract('DutchExchange - settleFee', accounts => {
   const calculateFeeInUSD = async (fee, token) => {
     const [ETHUSDPrice, [num, den]] = await Promise.all([
       oracle.getUSDETHPrice.call(),
-      dx.getPriceOfTokenInLastAuction.call(token),
+      dx.getPriceOfTokenInLastAuction.call(token)
     ])
 
     const feeInETH = calculateFee(fee, num.toNumber() / den.toNumber(), false)
@@ -495,7 +494,6 @@ const c2 = () => contract('DutchExchange - settleFee', accounts => {
 
     return adjustedFee
   }
-
 
   // it('amountAfterFee == amount when fee == 0.1', async () => {
   //   const feeRatio = await makeFeeRatioPercent(0.1, seller1)
@@ -542,7 +540,6 @@ const c2 = () => contract('DutchExchange - settleFee', accounts => {
 
     await settleFee(eth.address, gno.address, auctionIndex, seller1, amount, { from: seller1 })
     const extraTokens2 = await getExtraTokens(eth.address, gno.address, auctionIndex)
-
 
     assert.strictEqual(extraTokens1 + fee, extraTokens2, 'extraTokens should be increased by fee')
   })
@@ -602,13 +599,11 @@ const c2 = () => contract('DutchExchange - settleFee', accounts => {
 
     assert.strictEqual(owlBalance1, owlAmount, 'account should have OWL balance > feeInUSD / 2')
 
-
     await owl.approve(dx.address, owlAmount * 5, { from: seller1 })
 
-    const amountOfOWLBurned = Math.min(Math.floor(feeInUSD / 2), owlAmount);
+    const amountOfOWLBurned = Math.min(Math.floor(feeInUSD / 2), owlAmount)
     fee = adjustFee(fee, amountOfOWLBurned, feeInUSD)
     assert.isAbove(fee, 0, 'fee must be > 0')
-
 
     const auctionIndex = 1
 
@@ -671,6 +666,5 @@ const c2 = () => contract('DutchExchange - settleFee', accounts => {
     assert.strictEqual(owlBalance2, 0, 'all OWL should be burned as it was < feeInUSD/2 and all used up')
   })
 })
-
 
 enableContractFlag(c1, c2)

--- a/test/dutchExchange-startAuctionTheshold.spec.js
+++ b/test/dutchExchange-startAuctionTheshold.spec.js
@@ -6,8 +6,6 @@
 const {
   eventWatcher,
   log: utilsLog,
-  assertRejects,
-  enableContractFlag,
   gasLogger,
   makeSnapshot,
   revertSnapshot,
@@ -32,12 +30,8 @@ const {
 let snapshotId
 
 // Test VARS
-let eth, gno, dx, oracle
-
-let threshold, usdEthPrice
-let amountEthBelowThreshold, amountEthAboveThreshold, amountGnoBelowTheshold, amountGnoAboveThreshold
-
-let contracts
+let contracts, eth, gno, dx, oracle
+let usdEthPrice, amountEthBelowThreshold, amountEthAboveThreshold, amountGnoBelowTheshold, amountGnoAboveThreshold
 
 const separateLogs = () => utilsLog('\n    ----------------------------------')
 beforeEach(separateLogs)
@@ -238,7 +232,7 @@ contract('DutchExchange - start auction threshold', accounts => {
     assert.isAbove(auctionStart, now, 'The auction should be scheduled to start')
   })
 
-  it(`6. starts if theres enough funding in the opposite side and 24h goes by`, async () => {
+  it(`6. starts if there is enough funding in the opposite side and 24h goes by`, async () => {
     // GIVEN: Auction 2
     // GIVEN: waiting for funding
     // GIVEN: No sell volume
@@ -300,210 +294,6 @@ contract('DutchExchange - start auction threshold', accounts => {
     const auctionStart = await getAuctionStart(eth, gno)
     assert.isAbove(auctionStart, now, 'The auction should be scheduled to start')
   })
-
-  // it(' 2. check for a throw, if seller contribution == 0', async () => {
-  //   // prepare by clearing auction
-  //   let auctionIndex = await getAuctionIndex()
-  //   await waitUntilPriceIsXPercentOfPreviousPrice(eth, gno, 1)
-  //   await postBuyOrder(eth, gno, auctionIndex, totalBuyAmount, buyer1)
-  //   auctionIndex = await getAuctionIndex()
-  //   // await setAndCheckAuctionStarted(eth, gno)
-  //   assert.equal(2, auctionIndex)
-
-  //   // check that clearingTime was saved
-  //   const clearingTime = await getClearingTime(gno, eth, auctionIndex)
-  //   const now = timestamp()
-  //   assert.equal(clearingTime, now, 'clearingTime was set')
-
-  //   // check condition
-  //   assert.equal((await dx.sellerBalances.call(eth.address, gno.address, 1, seller2)).toNumber(), 0)
-  //   // now claiming should not be possible and return == 0
-  //   await assertRejects(dx.claimSellerFunds(eth.address, gno.address, seller2, 1))
-  // })
-
-  // it(' 3. check for the correct return value', async () => {
-  //   const auctionIndex = await getAuctionIndex()
-  //   const [claimedAmount] = (await dx.claimSellerFunds.call(eth.address, gno.address, seller1, auctionIndex - 1)).map(i => i.toNumber())
-  //   const [closingPriceNum] = (await dx.closingPrices.call(eth.address, gno.address, auctionIndex - 1)).map(i => i.toNumber())
-  //   assert.equal(claimedAmount, closingPriceNum)
-  // })
-
-  // describe('4. Test claim after selling', () => {
-  //   let currentSnapshotId
-  //   beforeEach(async () => {
-  //     currentSnapshotId = await makeSnapshot()
-  //   })
-
-  //   afterEach(async () => {
-  //     await revertSnapshot(currentSnapshotId)
-  //   })
-
-  //   it('4.1. It should claim seller funds in an auction with 2 sellers', async () => {
-  //     const auctionIndex = await getAuctionIndex()
-
-  //     await postSellOrder(gno, eth, 0, totalSellAmount2ndAuction / 5, seller2)
-  //     await postSellOrder(gno, eth, 0, totalSellAmount2ndAuction / 5, seller2)
-  //     await postSellOrder(gno, eth, 0, totalSellAmount2ndAuction * 3 / 5, seller1)
-  //     await postSellOrder(eth, gno, 0, totalSellAmount2ndAuction / 10, buyer2)
-
-  //     // closing new auction
-  //     await waitUntilPriceIsXPercentOfPreviousPrice(eth, gno, 1)
-  //     await postBuyOrder(gno, eth, auctionIndex, totalBuyAmount, buyer2)
-
-  //     // withdraw and check the balance change
-  //     const seller1BalanceBefore = await dx.balances.call(eth.address, seller1)
-  //     const seller2BalanceBefore = await dx.balances.call(eth.address, seller2)
-  //     await dx.claimSellerFunds(gno.address, eth.address, seller2, auctionIndex)
-  //     await dx.claimSellerFunds(gno.address, eth.address, seller1, auctionIndex)
-  //     const seller1BalanceAfter = await dx.balances.call(eth.address, seller1)
-  //     const seller2BalanceAfter = await dx.balances.call(eth.address, seller2)
-  //     const [closingPriceNum] = await dx.closingPrices.call(gno.address, eth.address, auctionIndex)
-  //     assert.equal(seller1BalanceBefore.add(closingPriceNum.mul(3).div(5)).toNumber(), seller1BalanceAfter.toNumber())
-  //     assert.equal(seller2BalanceBefore.add(closingPriceNum.mul(2).div(5)).toNumber(), seller2BalanceAfter.toNumber())
-
-  //     // check that the sellerBalances is set to 0
-  //     assert.equal((await dx.sellerBalances.call(gno.address, eth.address, auctionIndex, seller1)).toNumber(), 0)
-  //     assert.equal((await dx.sellerBalances.call(gno.address, eth.address, auctionIndex, seller1)).toNumber(), 0)
-  //   })
-
-  //   it('4.2. It should claim and withdraw seller funds in an auction with 2 sellers', async () => {
-  //     const auctionIndex = await getAuctionIndex()
-  //     // starting new auction with two sellers
-  //     await postSellOrder(gno, eth, 0, totalSellAmount2ndAuction / 5, seller2)
-  //     await postSellOrder(gno, eth, 0, totalSellAmount2ndAuction / 5, seller2)
-  //     await postSellOrder(gno, eth, 0, totalSellAmount2ndAuction * 3 / 5, seller1)
-  //     await postSellOrder(eth, gno, 0, totalSellAmount2ndAuction / 10, buyer2)
-
-  //     // closing new auction
-  //     await waitUntilPriceIsXPercentOfPreviousPrice(eth, gno, 1)
-  //     await postBuyOrder(gno, eth, auctionIndex, totalBuyAmount, buyer2)
-
-  //     // withdraw and check the balance change
-  //     const [claimableAmtS1] = (await dx.claimSellerFunds.call(gno.address, eth.address, seller1, auctionIndex)).map(s => s.toNumber())
-  //     const [claimableAmtS2] = (await dx.claimSellerFunds.call(gno.address, eth.address, seller2, auctionIndex)).map(s => s.toNumber())
-  //     const seller1ETHBal = (await dx.balances.call(eth.address, seller1)).toNumber()
-  //     const seller2ETHBal = (await dx.balances.call(eth.address, seller2)).toNumber()
-
-  //     // claim claimable tokens and withdraw at same time
-  //     await dx.claimAndWithdraw(gno.address, eth.address, seller2, auctionIndex, 10000.0.toWei(), { from: seller2 })
-  //     await dx.claimAndWithdraw(gno.address, eth.address, seller1, auctionIndex, 10000.0.toWei(), { from: seller1 })
-
-  //     const seller1ETHBalAfter = (await eth.balanceOf.call(seller1)).toNumber()
-  //     const seller2ETHBalAfter = (await eth.balanceOf.call(seller2)).toNumber()
-
-  //     // check that the sellerBalances is set to 0
-  //     // assert that balance in DX of ETH + ClaimedAndWithdraw-n amount = correct amount
-  //     assert.equal((await dx.sellerBalances.call(gno.address, eth.address, auctionIndex, seller1)).toNumber(), 0)
-  //     assert.equal((await dx.sellerBalances.call(gno.address, eth.address, auctionIndex, seller1)).toNumber(), 0)
-  //     assert.equal(seller1ETHBalAfter, seller1ETHBal + claimableAmtS1)
-  //     assert.equal(seller2ETHBalAfter, seller2ETHBal + claimableAmtS2)
-  //   })
-
-  //   it('5.1. It should claim seller funds in an auction with 2 sellers', async () => {
-  //     const auctionIndex = await getAuctionIndex()
-
-  //     await postSellOrder(gno, eth, 0, totalSellAmount2ndAuction / 5, seller2)
-  //     await postSellOrder(gno, eth, 0, totalSellAmount2ndAuction / 5, seller2)
-  //     await postSellOrder(gno, eth, 0, totalSellAmount2ndAuction * 3 / 5, seller1)
-  //     await postSellOrder(eth, gno, 0, 10e18, seller1)
-
-  //     // closing new auction
-  //     await waitUntilPriceIsXPercentOfPreviousPrice(eth, gno, 1)
-  //     await postBuyOrder(gno, eth, auctionIndex, totalBuyAmount, buyer2)
-  //     await postBuyOrder(eth, gno, auctionIndex, totalBuyAmount, buyer2)
-
-  //     await postSellOrder(gno, eth, 0, 5e18, seller1)
-  //     await postSellOrder(gno, eth, 0, 5e18, seller2)
-  //     await postSellOrder(eth, gno, 0, 10e18, seller1)
-  //     const auctionIndex2 = await getAuctionIndex()
-  //     assert.equal(auctionIndex2, 3)
-  //     await waitUntilPriceIsXPercentOfPreviousPrice(eth, gno, 1)
-  //     await postBuyOrder(gno, eth, auctionIndex + 1, totalBuyAmount, buyer1)
-
-  //     // withdraw and check the balance change
-  //     const seller1BalanceBefore = await dx.balances.call(eth.address, seller1)
-  //     const seller2BalanceBefore = await dx.balances.call(eth.address, seller2)
-  //     await dx.claimTokensFromSeveralAuctionsAsSeller(
-  //       [gno.address, gno.address], [eth.address, eth.address], [auctionIndex, auctionIndex + 1], seller2)
-  //     await dx.claimTokensFromSeveralAuctionsAsSeller(
-  //       [gno.address, gno.address], [eth.address, eth.address], [auctionIndex, auctionIndex + 1], seller1)
-  //     const seller1BalanceAfter = await dx.balances.call(eth.address, seller1)
-  //     const seller2BalanceAfter = await dx.balances.call(eth.address, seller2)
-  //     const [closingPrice1Num] = await dx.closingPrices.call(gno.address, eth.address, auctionIndex)
-  //     const [closingPrice2Num] = await dx.closingPrices.call(gno.address, eth.address, auctionIndex + 1)
-  //     const seller1BalanceCalc = seller1BalanceBefore.add(closingPrice1Num.mul(3).div(5))
-  //       .add(closingPrice2Num.mul(1).div(2))
-  //     const seller2BalanceCalc = seller2BalanceBefore.add(closingPrice1Num.mul(2).div(5))
-  //       .add(closingPrice2Num.mul(1).div(2))
-  //     assert.equal(seller1BalanceCalc.toNumber(), seller1BalanceAfter.toNumber())
-  //     assert.equal(seller2BalanceCalc.toNumber(), seller2BalanceAfter.toNumber())
-
-  //     // check that the sellerBalances is set to 0
-  //     assert.equal((await dx.sellerBalances.call(gno.address, eth.address, auctionIndex, seller1)).toNumber(), 0)
-  //     assert.equal((await dx.sellerBalances.call(gno.address, eth.address, auctionIndex, seller1)).toNumber(), 0)
-  //   })
-
-  //   it('5.2. It should claim and withdraw seller funds in an auction with 2 sellers', async () => {
-  //     const auctionIndex = await getAuctionIndex()
-  //     // starting new auction with two sellers
-  //     await postSellOrder(gno, eth, 0, totalSellAmount2ndAuction / 5, seller2)
-  //     await postSellOrder(gno, eth, 0, totalSellAmount2ndAuction / 5, seller2)
-  //     await postSellOrder(gno, eth, 0, totalSellAmount2ndAuction * 3 / 5, seller1)
-  //     await postSellOrder(eth, gno, 0, 10e18, seller1)
-
-  //     // closing new auction
-  //     await waitUntilPriceIsXPercentOfPreviousPrice(eth, gno, 1)
-  //     await postBuyOrder(gno, eth, auctionIndex, totalBuyAmount, buyer2)
-  //     await postBuyOrder(eth, gno, auctionIndex, totalBuyAmount, buyer2)
-
-  //     await postSellOrder(gno, eth, 0, 5e18, seller1)
-  //     await postSellOrder(gno, eth, 0, 5e18, seller2)
-  //     await postSellOrder(eth, gno, 0, 10e18, seller1)
-  //     const auctionIndex2 = await getAuctionIndex()
-  //     assert.equal(auctionIndex2, 3)
-  //     await waitUntilPriceIsXPercentOfPreviousPrice(eth, gno, 1)
-  //     await postBuyOrder(gno, eth, auctionIndex + 1, totalBuyAmount, buyer1)
-
-  //     // withdraw and check the balance change
-  //     const [claimableAmtS1] = (await dx.claimTokensFromSeveralAuctionsAsSeller.call(
-  //       [gno.address, gno.address], [eth.address, eth.address], [auctionIndex, auctionIndex + 1], seller1))
-  //       .map(result => {
-  //         return result.map(value => value.toNumber())
-  //       })
-  //     const [claimableAmtS2] = (await dx.claimTokensFromSeveralAuctionsAsSeller.call(
-  //       [gno.address, gno.address], [eth.address, eth.address], [auctionIndex, auctionIndex + 1], seller2))
-  //       .map(result => {
-  //         return result.map(value => value.toNumber())
-  //       })
-  //     const claimedAmountsS1 = claimableAmtS1.reduce((acc, amount) => {
-  //       return acc + amount
-  //     }, 0)
-  //     const claimedAmountsS2 = claimableAmtS2.reduce((acc, amount) => {
-  //       return acc + amount
-  //     }, 0)
-  //     const seller1ETHBal = (await dx.balances.call(eth.address, seller1)).toNumber()
-  //     const seller2ETHBal = (await dx.balances.call(eth.address, seller2)).toNumber()
-  //     // Not deposited seller balances
-  //     const seller1NotDepositedETHBal = (await eth.balanceOf.call(seller1)).toNumber()
-  //     const seller2NotDepositedETHBal = (await eth.balanceOf.call(seller2)).toNumber()
-
-  //     // claim claimable tokens and withdraw at same time
-  //     await dx.claimAndWithdrawTokensFromSeveralAuctionsAsSeller(
-  //       [gno.address, gno.address], [eth.address, eth.address], [auctionIndex, auctionIndex + 1], { from: seller1 })
-  //     await dx.claimAndWithdrawTokensFromSeveralAuctionsAsSeller(
-  //       [gno.address, gno.address], [eth.address, eth.address], [auctionIndex, auctionIndex + 1], { from: seller2 })
-
-  //     // check that the sellerBalances is set to 0
-  //     // assert that balance in DX of ETH + ClaimedAndWithdraw-n amount = correct amount
-  //     assert.equal((await dx.sellerBalances.call(gno.address, eth.address, auctionIndex, seller1)).toNumber(), 0)
-  //     assert.equal((await dx.sellerBalances.call(gno.address, eth.address, auctionIndex, seller1)).toNumber(), 0)
-  //     assert.equal(seller1NotDepositedETHBal + claimedAmountsS1, (await eth.balanceOf.call(seller1)).toNumber())
-  //     assert.equal(seller2NotDepositedETHBal + claimedAmountsS2, (await eth.balanceOf.call(seller2)).toNumber())
-  //     // assert that claimed and withdrawed the amount (same deposited in DX)
-  //     assert.equal(seller1ETHBal, (await dx.balances.call(eth.address, seller1)).toNumber())
-  //     assert.equal(seller2ETHBal, (await dx.balances.call(eth.address, seller2)).toNumber())
-  //   })
-  // })
 
   const getSellerBalance = async (account, sellToken, buyToken, auctionIndex) =>
     (await dx.sellerBalances.call(sellToken.address || sellToken, buyToken.address || buyToken, auctionIndex, account))

--- a/test/dutchExchange-startAuctionTheshold.spec.js
+++ b/test/dutchExchange-startAuctionTheshold.spec.js
@@ -1,0 +1,511 @@
+/* global contract, assert, timestamp */
+/* eslint no-undef: "error" */
+
+/* Fee Reduction Token issuing is tested seperately in dutchExchange-MGN.js */
+
+const {
+  eventWatcher,
+  log: utilsLog,
+  assertRejects,
+  enableContractFlag,
+  gasLogger,
+  makeSnapshot,
+  revertSnapshot,
+  timestamp,
+  AUCTION_START_WAITING_FOR_FUNDING
+} = require('./utils')
+
+const SECONDS_24H = 86405
+
+const {
+  setupTest,
+  getContracts,
+  getAuctionIndex,
+  waitUntilPriceIsXPercentOfPreviousPrice,
+  setAndCheckAuctionStarted,
+  postBuyOrder,
+  postSellOrder,
+  getAuctionStart,
+  wait
+} = require('./testFunctions')
+// Restore state
+let snapshotId
+
+// Test VARS
+let eth, gno, dx, oracle
+
+let threshold, usdEthPrice
+let amountEthBelowThreshold, amountEthAboveThreshold, amountGnoBelowTheshold, amountGnoAboveThreshold
+
+let contracts
+
+const separateLogs = () => utilsLog('\n    ----------------------------------')
+beforeEach(separateLogs)
+afterEach(gasLogger)
+
+const log = (...args) => utilsLog('\t', ...args)
+
+const setupContracts = async () => {
+  contracts = await getContracts();
+  // destructure contracts into upper state
+  ({
+    DutchExchange: dx,
+    EtherToken: eth,
+    TokenGNO: gno,
+    PriceOracleInterface: oracle
+  } = contracts)
+}
+
+const setupAmountUsedForTesting = async () => {
+  // Amounts used for testing
+  const [threshold, usdEthPriceAux, gnoEthPrice] = await Promise.all([
+    dx.thresholdNewAuction().then(bn => bn.div(1e18).toNumber()),
+    oracle.getUSDETHPrice.call().then(bn => bn.toNumber()),
+    dx.getPriceOfTokenInLastAuction.call(gno.address).then(([num, den]) => num.div(den).toNumber())
+  ])
+  usdEthPrice = usdEthPriceAux
+  log(`Threshold to start an auction: ${threshold}`)
+  log(`USD-ETH price: ${usdEthPrice}`)
+  log(`ETH-GNO price: ${gnoEthPrice}`)
+
+  amountEthBelowThreshold = threshold * 0.9 / usdEthPrice
+  amountEthAboveThreshold = threshold * 1.1 / usdEthPrice
+  amountGnoBelowTheshold = threshold * 0.9 / usdEthPrice / gnoEthPrice
+  amountGnoAboveThreshold = threshold * 1.1 / usdEthPrice / gnoEthPrice
+
+  log(`Amounts used for testing:' 
+    ETH:
+      - below: ${amountEthBelowThreshold}
+      - above: ${amountEthAboveThreshold}
+    GNO:
+      - below: ${amountGnoBelowTheshold}
+      - above: ${amountGnoAboveThreshold}
+  `)
+}
+
+const startBal = {
+  startingETH: 90.0.toWei(),
+  startingGNO: 90.0.toWei(),
+  ethUSDPrice: 1008.0.toWei(),
+  sellingAmount: 50.0.toWei() // Same as web3.toWei(50, 'ether')
+}
+
+contract('DutchExchange - start auction threshold', accounts => {
+  const [, seller1] = accounts
+  // const totalSellAmount2ndAuction = 10e18
+  // const totalBuyAmount = 2 * 10e18
+  before(async () => {
+    // get contracts
+    await setupContracts()
+
+    // set up accounts and tokens[contracts]
+    await setupTest(accounts, contracts, startBal)
+
+    // add tokenPair ETH GNO
+    await dx.addTokenPair(
+      eth.address,
+      gno.address,
+      10.0.toWei(),
+      0,
+      2,
+      1,
+      { from: seller1 }
+    )
+
+    await setupAmountUsedForTesting()
+
+    // const auctionIndex = await getAuctionIndex()
+    log('Start first auction')
+    await setAndCheckAuctionStarted(eth, gno)
+
+    log('Wait until we reach the prior price. 2 GNO = 1 WETH')
+    await waitUntilPriceIsXPercentOfPreviousPrice(eth, gno, 1)
+
+    log('Close the first auction using 25 GNO')
+    await postBuyOrder(eth, gno, 1, 25.0.toWei(), seller1)
+
+    log('Take snapshot of Ganache: Auction 1 just cleared')
+    snapshotId = makeSnapshot()
+  })
+
+  afterEach(gasLogger)
+  afterEach(async () => {
+    // log('Revert snapshot of Ganache')
+    await revertSnapshot(snapshotId)
+    snapshotId = makeSnapshot()
+  })
+
+  after(eventWatcher.stopWatching)
+
+  it("1. doesn't start the auction when sellVolume is below the threshold in both sides", async () => {
+    // GIVEN: Auction 2
+    const auctionIndex = await getAuctionIndex(eth, gno)
+    assert.strictEqual(auctionIndex, 2, 'should be in auction 2')
+
+    // GIVEN: waiting for funding
+    let auctionStart = await getAuctionStart(eth, gno)
+    assert.strictEqual(auctionStart, AUCTION_START_WAITING_FOR_FUNDING, 'should be waiting for funding')
+
+    // GIVEN: No sell volume
+    const [sellerBalance, sellerBalanceOpp] = await Promise.all([
+      getSellerBalance(seller1, eth, gno, auctionIndex),
+      getSellerBalance(seller1, gno, eth, auctionIndex)
+    ])
+    assert.strictEqual(sellerBalance + sellerBalanceOpp, 0, 'no sell volume in any of the sides')
+
+    // WHEN: A seller sell, below the threshold in ANY of the sides
+    log(`Posting sell order below threshold --> WETH-GNO-${auctionIndex}: ${amountEthBelowThreshold}`)
+    await postSellOrder(eth, gno, auctionIndex, amountEthBelowThreshold.toWei(), seller1)
+    log(`Posting sell order below threshold --> GNO-WETH-${auctionIndex}: ${amountGnoBelowTheshold}`)
+    await postSellOrder(gno, eth, auctionIndex, amountGnoBelowTheshold.toWei(), seller1)
+
+    // THEN: The auction remains unscheduled
+    auctionStart = await getAuctionStart(eth, gno)
+    assert.strictEqual(auctionStart, AUCTION_START_WAITING_FOR_FUNDING, 'The auction should remain unscheduled')
+  })
+
+  it(`2. does't start if we surplus one of the sides`, async () => {
+    // GIVEN: Auction 2
+    // GIVEN: waiting for funding
+    // GIVEN: No sell volume
+    //  Checked already in 1.
+
+    // WHEN: We surplus only one of the sides
+    const auctionIndex = await getAuctionIndex(eth, gno)
+    log(`Posting sell order above threshold --> WETH-GNO-${auctionIndex}: ${amountEthAboveThreshold}`)
+    await postSellOrder(eth, gno, auctionIndex, amountEthAboveThreshold.toWei(), seller1)
+
+    // THEN: The auction remains unscheduled
+    const auctionStart = await getAuctionStart(eth, gno)
+    assert.strictEqual(auctionStart, AUCTION_START_WAITING_FOR_FUNDING, 'The auction should remain unscheduled')
+  })
+
+  it(`3. does't start if we surplus the opposite side`, async () => {
+    // GIVEN: Auction 2
+    // GIVEN: waiting for funding
+    // GIVEN: No sell volume
+    //  Checked already in 1.
+
+    // WHEN: We surplus only the opposite side
+    const auctionIndex = await getAuctionIndex(eth, gno)
+    log(`Posting sell order above threshold --> GNO-WETH-${auctionIndex}: ${amountGnoAboveThreshold}`)
+    await postSellOrder(gno, eth, auctionIndex, amountGnoAboveThreshold.toWei(), seller1)
+
+    // THEN: The auction remains unscheduled
+    const auctionStart = await getAuctionStart(eth, gno)
+    assert.strictEqual(auctionStart, AUCTION_START_WAITING_FOR_FUNDING, 'The auction should remain unscheduled')
+  })
+
+  it(`4. starts if we surplus both sides`, async () => {
+    // GIVEN: Auction 2
+    // GIVEN: waiting for funding
+    // GIVEN: No sell volume
+    //  Checked already in 1.
+
+    // WHEN: We surplus both sides
+    const auctionIndex = await getAuctionIndex(eth, gno)
+    const now = timestamp()
+    log(`Posting sell order below threshold --> WETH-GNO-${auctionIndex}: ${amountEthAboveThreshold}`)
+    await postSellOrder(eth, gno, auctionIndex, amountEthAboveThreshold.toWei(), seller1)
+    log(`Posting sell order below threshold --> GNO-WETH-${auctionIndex}: ${amountGnoAboveThreshold}`)
+    await postSellOrder(gno, eth, auctionIndex, amountGnoAboveThreshold.toWei(), seller1)
+
+    // THEN: The auction is scheduled
+    const auctionStart = await getAuctionStart(eth, gno)
+    assert.isAbove(auctionStart, now, 'The auction should be scheduled to start')
+  })
+
+  it(`5. starts if there is enough funding in one side and 24h goes by`, async () => {
+    // GIVEN: Auction 2
+    // GIVEN: waiting for funding
+    // GIVEN: No sell volume
+    //  Checked already in 1.
+
+    // WHEN: We surplus only one of the sides
+    const auctionIndex = await getAuctionIndex(eth, gno)
+    const now = timestamp()
+    log(`Posting sell order above threshold --> WETH-GNO-${auctionIndex}: ${amountEthAboveThreshold}`)
+    await postSellOrder(eth, gno, auctionIndex, amountEthAboveThreshold.toWei(), seller1)
+
+    // WHEN: 24h goes by
+    await wait(SECONDS_24H)
+
+    // WHEN: A seller "poke" the contract
+    await postSellOrder(eth, gno, auctionIndex, 0.0, seller1)
+
+    // THEN: The auction is scheduled
+    const auctionStart = await getAuctionStart(eth, gno)
+    assert.isAbove(auctionStart, now, 'The auction should be scheduled to start')
+  })
+
+  it(`6. starts if theres enough funding in the opposite side and 24h goes by`, async () => {
+    // GIVEN: Auction 2
+    // GIVEN: waiting for funding
+    // GIVEN: No sell volume
+    //  Checked already in 1.
+
+    // WHEN: We surplus the opposite side
+    const auctionIndex = await getAuctionIndex(eth, gno)
+    const now = timestamp()
+    log(`Posting sell order above threshold --> GNO-WETH-${auctionIndex}: ${amountGnoAboveThreshold}`)
+    await postSellOrder(gno, eth, auctionIndex, amountGnoAboveThreshold.toWei(), seller1)
+
+    // WHEN: 24h goes by
+    await wait(SECONDS_24H)
+
+    // WHEN: A seller "poke" the contract
+    await postSellOrder(eth, gno, auctionIndex, 0.0, seller1)
+
+    // THEN: The auction is scheduled
+    const auctionStart = await getAuctionStart(eth, gno)
+    assert.isAbove(auctionStart, now, 'The auction should be scheduled to start')
+  })
+
+  it(`7. starts if after 24h, someone surplus one side`, async () => {
+    // GIVEN: Auction 2
+    // GIVEN: waiting for funding
+    // GIVEN: No sell volume
+    //  Checked already in 1.
+
+    // WHEN: 24h goes by
+    await wait(SECONDS_24H)
+
+    // WHEN: We surplus the opposite side
+    const auctionIndex = await getAuctionIndex(eth, gno)
+    const now = timestamp()
+    log(`Posting sell order above threshold --> WETH-GNO-${auctionIndex}: ${amountEthAboveThreshold}`)
+    await postSellOrder(eth, gno, auctionIndex, amountEthAboveThreshold.toWei(), seller1)
+
+    // THEN: The auction is scheduled
+    const auctionStart = await getAuctionStart(eth, gno)
+    assert.isAbove(auctionStart, now, 'The auction should be scheduled to start')
+  })
+
+  it(`8. starts if after 24h, someone surplus the opposite side`, async () => {
+    // GIVEN: Auction 2
+    // GIVEN: waiting for funding
+    // GIVEN: No sell volume
+    //  Checked already in 1.
+
+    // WHEN: 24h goes by
+    await wait(SECONDS_24H)
+
+    // WHEN: We surplus the opposite side
+    const auctionIndex = await getAuctionIndex(eth, gno)
+    const now = timestamp()
+    log(`Posting sell order above threshold --> GNO-WETH-${auctionIndex}: ${amountGnoAboveThreshold}`)
+    await postSellOrder(gno, eth, auctionIndex, amountGnoAboveThreshold.toWei(), seller1)
+
+    // THEN: The auction is scheduled
+    const auctionStart = await getAuctionStart(eth, gno)
+    assert.isAbove(auctionStart, now, 'The auction should be scheduled to start')
+  })
+
+  // it(' 2. check for a throw, if seller contribution == 0', async () => {
+  //   // prepare by clearing auction
+  //   let auctionIndex = await getAuctionIndex()
+  //   await waitUntilPriceIsXPercentOfPreviousPrice(eth, gno, 1)
+  //   await postBuyOrder(eth, gno, auctionIndex, totalBuyAmount, buyer1)
+  //   auctionIndex = await getAuctionIndex()
+  //   // await setAndCheckAuctionStarted(eth, gno)
+  //   assert.equal(2, auctionIndex)
+
+  //   // check that clearingTime was saved
+  //   const clearingTime = await getClearingTime(gno, eth, auctionIndex)
+  //   const now = timestamp()
+  //   assert.equal(clearingTime, now, 'clearingTime was set')
+
+  //   // check condition
+  //   assert.equal((await dx.sellerBalances.call(eth.address, gno.address, 1, seller2)).toNumber(), 0)
+  //   // now claiming should not be possible and return == 0
+  //   await assertRejects(dx.claimSellerFunds(eth.address, gno.address, seller2, 1))
+  // })
+
+  // it(' 3. check for the correct return value', async () => {
+  //   const auctionIndex = await getAuctionIndex()
+  //   const [claimedAmount] = (await dx.claimSellerFunds.call(eth.address, gno.address, seller1, auctionIndex - 1)).map(i => i.toNumber())
+  //   const [closingPriceNum] = (await dx.closingPrices.call(eth.address, gno.address, auctionIndex - 1)).map(i => i.toNumber())
+  //   assert.equal(claimedAmount, closingPriceNum)
+  // })
+
+  // describe('4. Test claim after selling', () => {
+  //   let currentSnapshotId
+  //   beforeEach(async () => {
+  //     currentSnapshotId = await makeSnapshot()
+  //   })
+
+  //   afterEach(async () => {
+  //     await revertSnapshot(currentSnapshotId)
+  //   })
+
+  //   it('4.1. It should claim seller funds in an auction with 2 sellers', async () => {
+  //     const auctionIndex = await getAuctionIndex()
+
+  //     await postSellOrder(gno, eth, 0, totalSellAmount2ndAuction / 5, seller2)
+  //     await postSellOrder(gno, eth, 0, totalSellAmount2ndAuction / 5, seller2)
+  //     await postSellOrder(gno, eth, 0, totalSellAmount2ndAuction * 3 / 5, seller1)
+  //     await postSellOrder(eth, gno, 0, totalSellAmount2ndAuction / 10, buyer2)
+
+  //     // closing new auction
+  //     await waitUntilPriceIsXPercentOfPreviousPrice(eth, gno, 1)
+  //     await postBuyOrder(gno, eth, auctionIndex, totalBuyAmount, buyer2)
+
+  //     // withdraw and check the balance change
+  //     const seller1BalanceBefore = await dx.balances.call(eth.address, seller1)
+  //     const seller2BalanceBefore = await dx.balances.call(eth.address, seller2)
+  //     await dx.claimSellerFunds(gno.address, eth.address, seller2, auctionIndex)
+  //     await dx.claimSellerFunds(gno.address, eth.address, seller1, auctionIndex)
+  //     const seller1BalanceAfter = await dx.balances.call(eth.address, seller1)
+  //     const seller2BalanceAfter = await dx.balances.call(eth.address, seller2)
+  //     const [closingPriceNum] = await dx.closingPrices.call(gno.address, eth.address, auctionIndex)
+  //     assert.equal(seller1BalanceBefore.add(closingPriceNum.mul(3).div(5)).toNumber(), seller1BalanceAfter.toNumber())
+  //     assert.equal(seller2BalanceBefore.add(closingPriceNum.mul(2).div(5)).toNumber(), seller2BalanceAfter.toNumber())
+
+  //     // check that the sellerBalances is set to 0
+  //     assert.equal((await dx.sellerBalances.call(gno.address, eth.address, auctionIndex, seller1)).toNumber(), 0)
+  //     assert.equal((await dx.sellerBalances.call(gno.address, eth.address, auctionIndex, seller1)).toNumber(), 0)
+  //   })
+
+  //   it('4.2. It should claim and withdraw seller funds in an auction with 2 sellers', async () => {
+  //     const auctionIndex = await getAuctionIndex()
+  //     // starting new auction with two sellers
+  //     await postSellOrder(gno, eth, 0, totalSellAmount2ndAuction / 5, seller2)
+  //     await postSellOrder(gno, eth, 0, totalSellAmount2ndAuction / 5, seller2)
+  //     await postSellOrder(gno, eth, 0, totalSellAmount2ndAuction * 3 / 5, seller1)
+  //     await postSellOrder(eth, gno, 0, totalSellAmount2ndAuction / 10, buyer2)
+
+  //     // closing new auction
+  //     await waitUntilPriceIsXPercentOfPreviousPrice(eth, gno, 1)
+  //     await postBuyOrder(gno, eth, auctionIndex, totalBuyAmount, buyer2)
+
+  //     // withdraw and check the balance change
+  //     const [claimableAmtS1] = (await dx.claimSellerFunds.call(gno.address, eth.address, seller1, auctionIndex)).map(s => s.toNumber())
+  //     const [claimableAmtS2] = (await dx.claimSellerFunds.call(gno.address, eth.address, seller2, auctionIndex)).map(s => s.toNumber())
+  //     const seller1ETHBal = (await dx.balances.call(eth.address, seller1)).toNumber()
+  //     const seller2ETHBal = (await dx.balances.call(eth.address, seller2)).toNumber()
+
+  //     // claim claimable tokens and withdraw at same time
+  //     await dx.claimAndWithdraw(gno.address, eth.address, seller2, auctionIndex, 10000.0.toWei(), { from: seller2 })
+  //     await dx.claimAndWithdraw(gno.address, eth.address, seller1, auctionIndex, 10000.0.toWei(), { from: seller1 })
+
+  //     const seller1ETHBalAfter = (await eth.balanceOf.call(seller1)).toNumber()
+  //     const seller2ETHBalAfter = (await eth.balanceOf.call(seller2)).toNumber()
+
+  //     // check that the sellerBalances is set to 0
+  //     // assert that balance in DX of ETH + ClaimedAndWithdraw-n amount = correct amount
+  //     assert.equal((await dx.sellerBalances.call(gno.address, eth.address, auctionIndex, seller1)).toNumber(), 0)
+  //     assert.equal((await dx.sellerBalances.call(gno.address, eth.address, auctionIndex, seller1)).toNumber(), 0)
+  //     assert.equal(seller1ETHBalAfter, seller1ETHBal + claimableAmtS1)
+  //     assert.equal(seller2ETHBalAfter, seller2ETHBal + claimableAmtS2)
+  //   })
+
+  //   it('5.1. It should claim seller funds in an auction with 2 sellers', async () => {
+  //     const auctionIndex = await getAuctionIndex()
+
+  //     await postSellOrder(gno, eth, 0, totalSellAmount2ndAuction / 5, seller2)
+  //     await postSellOrder(gno, eth, 0, totalSellAmount2ndAuction / 5, seller2)
+  //     await postSellOrder(gno, eth, 0, totalSellAmount2ndAuction * 3 / 5, seller1)
+  //     await postSellOrder(eth, gno, 0, 10e18, seller1)
+
+  //     // closing new auction
+  //     await waitUntilPriceIsXPercentOfPreviousPrice(eth, gno, 1)
+  //     await postBuyOrder(gno, eth, auctionIndex, totalBuyAmount, buyer2)
+  //     await postBuyOrder(eth, gno, auctionIndex, totalBuyAmount, buyer2)
+
+  //     await postSellOrder(gno, eth, 0, 5e18, seller1)
+  //     await postSellOrder(gno, eth, 0, 5e18, seller2)
+  //     await postSellOrder(eth, gno, 0, 10e18, seller1)
+  //     const auctionIndex2 = await getAuctionIndex()
+  //     assert.equal(auctionIndex2, 3)
+  //     await waitUntilPriceIsXPercentOfPreviousPrice(eth, gno, 1)
+  //     await postBuyOrder(gno, eth, auctionIndex + 1, totalBuyAmount, buyer1)
+
+  //     // withdraw and check the balance change
+  //     const seller1BalanceBefore = await dx.balances.call(eth.address, seller1)
+  //     const seller2BalanceBefore = await dx.balances.call(eth.address, seller2)
+  //     await dx.claimTokensFromSeveralAuctionsAsSeller(
+  //       [gno.address, gno.address], [eth.address, eth.address], [auctionIndex, auctionIndex + 1], seller2)
+  //     await dx.claimTokensFromSeveralAuctionsAsSeller(
+  //       [gno.address, gno.address], [eth.address, eth.address], [auctionIndex, auctionIndex + 1], seller1)
+  //     const seller1BalanceAfter = await dx.balances.call(eth.address, seller1)
+  //     const seller2BalanceAfter = await dx.balances.call(eth.address, seller2)
+  //     const [closingPrice1Num] = await dx.closingPrices.call(gno.address, eth.address, auctionIndex)
+  //     const [closingPrice2Num] = await dx.closingPrices.call(gno.address, eth.address, auctionIndex + 1)
+  //     const seller1BalanceCalc = seller1BalanceBefore.add(closingPrice1Num.mul(3).div(5))
+  //       .add(closingPrice2Num.mul(1).div(2))
+  //     const seller2BalanceCalc = seller2BalanceBefore.add(closingPrice1Num.mul(2).div(5))
+  //       .add(closingPrice2Num.mul(1).div(2))
+  //     assert.equal(seller1BalanceCalc.toNumber(), seller1BalanceAfter.toNumber())
+  //     assert.equal(seller2BalanceCalc.toNumber(), seller2BalanceAfter.toNumber())
+
+  //     // check that the sellerBalances is set to 0
+  //     assert.equal((await dx.sellerBalances.call(gno.address, eth.address, auctionIndex, seller1)).toNumber(), 0)
+  //     assert.equal((await dx.sellerBalances.call(gno.address, eth.address, auctionIndex, seller1)).toNumber(), 0)
+  //   })
+
+  //   it('5.2. It should claim and withdraw seller funds in an auction with 2 sellers', async () => {
+  //     const auctionIndex = await getAuctionIndex()
+  //     // starting new auction with two sellers
+  //     await postSellOrder(gno, eth, 0, totalSellAmount2ndAuction / 5, seller2)
+  //     await postSellOrder(gno, eth, 0, totalSellAmount2ndAuction / 5, seller2)
+  //     await postSellOrder(gno, eth, 0, totalSellAmount2ndAuction * 3 / 5, seller1)
+  //     await postSellOrder(eth, gno, 0, 10e18, seller1)
+
+  //     // closing new auction
+  //     await waitUntilPriceIsXPercentOfPreviousPrice(eth, gno, 1)
+  //     await postBuyOrder(gno, eth, auctionIndex, totalBuyAmount, buyer2)
+  //     await postBuyOrder(eth, gno, auctionIndex, totalBuyAmount, buyer2)
+
+  //     await postSellOrder(gno, eth, 0, 5e18, seller1)
+  //     await postSellOrder(gno, eth, 0, 5e18, seller2)
+  //     await postSellOrder(eth, gno, 0, 10e18, seller1)
+  //     const auctionIndex2 = await getAuctionIndex()
+  //     assert.equal(auctionIndex2, 3)
+  //     await waitUntilPriceIsXPercentOfPreviousPrice(eth, gno, 1)
+  //     await postBuyOrder(gno, eth, auctionIndex + 1, totalBuyAmount, buyer1)
+
+  //     // withdraw and check the balance change
+  //     const [claimableAmtS1] = (await dx.claimTokensFromSeveralAuctionsAsSeller.call(
+  //       [gno.address, gno.address], [eth.address, eth.address], [auctionIndex, auctionIndex + 1], seller1))
+  //       .map(result => {
+  //         return result.map(value => value.toNumber())
+  //       })
+  //     const [claimableAmtS2] = (await dx.claimTokensFromSeveralAuctionsAsSeller.call(
+  //       [gno.address, gno.address], [eth.address, eth.address], [auctionIndex, auctionIndex + 1], seller2))
+  //       .map(result => {
+  //         return result.map(value => value.toNumber())
+  //       })
+  //     const claimedAmountsS1 = claimableAmtS1.reduce((acc, amount) => {
+  //       return acc + amount
+  //     }, 0)
+  //     const claimedAmountsS2 = claimableAmtS2.reduce((acc, amount) => {
+  //       return acc + amount
+  //     }, 0)
+  //     const seller1ETHBal = (await dx.balances.call(eth.address, seller1)).toNumber()
+  //     const seller2ETHBal = (await dx.balances.call(eth.address, seller2)).toNumber()
+  //     // Not deposited seller balances
+  //     const seller1NotDepositedETHBal = (await eth.balanceOf.call(seller1)).toNumber()
+  //     const seller2NotDepositedETHBal = (await eth.balanceOf.call(seller2)).toNumber()
+
+  //     // claim claimable tokens and withdraw at same time
+  //     await dx.claimAndWithdrawTokensFromSeveralAuctionsAsSeller(
+  //       [gno.address, gno.address], [eth.address, eth.address], [auctionIndex, auctionIndex + 1], { from: seller1 })
+  //     await dx.claimAndWithdrawTokensFromSeveralAuctionsAsSeller(
+  //       [gno.address, gno.address], [eth.address, eth.address], [auctionIndex, auctionIndex + 1], { from: seller2 })
+
+  //     // check that the sellerBalances is set to 0
+  //     // assert that balance in DX of ETH + ClaimedAndWithdraw-n amount = correct amount
+  //     assert.equal((await dx.sellerBalances.call(gno.address, eth.address, auctionIndex, seller1)).toNumber(), 0)
+  //     assert.equal((await dx.sellerBalances.call(gno.address, eth.address, auctionIndex, seller1)).toNumber(), 0)
+  //     assert.equal(seller1NotDepositedETHBal + claimedAmountsS1, (await eth.balanceOf.call(seller1)).toNumber())
+  //     assert.equal(seller2NotDepositedETHBal + claimedAmountsS2, (await eth.balanceOf.call(seller2)).toNumber())
+  //     // assert that claimed and withdrawed the amount (same deposited in DX)
+  //     assert.equal(seller1ETHBal, (await dx.balances.call(eth.address, seller1)).toNumber())
+  //     assert.equal(seller2ETHBal, (await dx.balances.call(eth.address, seller2)).toNumber())
+  //   })
+  // })
+
+  const getSellerBalance = async (account, sellToken, buyToken, auctionIndex) =>
+    (await dx.sellerBalances.call(sellToken.address || sellToken, buyToken.address || buyToken, auctionIndex, account))
+      .toNumber()
+})

--- a/test/resources/add-token-pair/rinkeby/03_dxDao.js
+++ b/test/resources/add-token-pair/rinkeby/03_dxDao.js
@@ -5,8 +5,8 @@ module.exports = [
   require('./WETH_OMG.js'),
 
   // WETH-OMG
-  require('./WETH_RDN.js'),
+  require('./WETH_RDN.js')
 
   // RDN-OMG
-  require('./RDN_OMG.js')
+  // require('./RDN_OMG.js')
 ]

--- a/test/stateTransitions.spec.js
+++ b/test/stateTransitions.spec.js
@@ -1,3 +1,6 @@
+/* global contract, assert */
+/* eslint no-undef: "error" */
+
 // This file tests all the states and their interaction as outlined here:
 // https://drive.google.com/drive/folders/0ByHhiGx-ltJZczhjZHhHeGpHcHM
 // States are generated with the function getIntoState and
@@ -108,7 +111,7 @@ const getState = async (ST, BT) => {
     (dx.closingPrices.call(ST.address, BT.address, auctionIndex))
   ])
 
-  const isAuctionTheoreticalClosed = (numP.mul(denBasedOnVolume).sub(numBasedOnVolume.mul(denP)).toNumber() <= 0);
+  const isAuctionTheoreticalClosed = (numP.mul(denBasedOnVolume).sub(numBasedOnVolume.mul(denP)).toNumber() <= 0)
   const isAuctionClosed = (numPP.toNumber() > 0)
 
   // calculate state of OppAuction
@@ -124,7 +127,7 @@ const getState = async (ST, BT) => {
     (dx.closingPrices.call(BT.address, ST.address, auctionIndex))
   ])
 
-  const isOppAuctionTheoreticalClosed = (numP2.mul(denBasedOnVolumeOpp).minus(numBasedOnVolumeOpp.mul(denP2)).toNumber() <= 0);
+  const isOppAuctionTheoreticalClosed = (numP2.mul(denBasedOnVolumeOpp).minus(numBasedOnVolumeOpp.mul(denP2)).toNumber() <= 0)
   const isOppAuctionClosed = (numPPOpp.toNumber() > 0)
 
   // Got sellVolumesCurrent as denominator based on volume. Rename for better reading
@@ -400,7 +403,7 @@ contract('DutchExchange - stateTransitions', accounts => {
       // clearing first auction
       await postBuyOrder(eth, gno, auctionIndex, 10.0.toWei() * 3, buyer1)
 
-      const[ state ] = await Promise.all([
+      const [state] = await Promise.all([
         getState(eth, gno),
         // checkState = async (auctionIndex, auctionStart, sellVolumesCurrent, sellVolumesNext, buyVolumes, closingPriceNum, closingPriceDen, ST, BT, MaxRoundingError) => {
         checkState(1, auctionStart, valMinusFee(10.0.toWei()), 0, valMinusFee(10.0.toWei() * 3), valMinusFee(10.0.toWei()) * 3, valMinusFee(10.0.toWei()), eth, gno, 10 ** 16),
@@ -421,7 +424,7 @@ contract('DutchExchange - stateTransitions', accounts => {
       await assertRejects(postSellOrder(eth, gno, auctionIndex, 10.0.toWei() * 3, seller1))
       await assertRejects(postSellOrder(eth, gno, auctionIndex + 2, 10.0.toWei() * 3, seller1))
 
-      const [ state ] = await Promise.all([
+      const [state] = await Promise.all([
         getState(eth, gno),
         // checkState = async (auctionIndex, auctionStart, sellVolumesCurrent, sellVolumesNext, buyVolumes, closingPriceNum, closingPriceDen, ST, BT, MaxRoundingError) => {
         checkState(1, auctionStart, valMinusFee(10.0.toWei()), valMinusFee(10.0.toWei() * 6), 0, 0, 0, eth, gno, 1),
@@ -498,7 +501,7 @@ contract('DutchExchange - stateTransitions', accounts => {
       // clearing first auction
       await assertRejects(postBuyOrder(gno, eth, auctionIndex, 10.0.toWei() * 3, buyer1))
 
-      const [ state ] = await Promise.all([
+      const [state] = await Promise.all([
         getState(eth, gno),
         // checkState = async (auctionIndex, auctionStart, sellVolumesCurrent, sellVolumesNext, buyVolumes, closingPriceNum, closingPriceDen, ST, BT, MaxRoundingError) => {
         checkState(1, auctionStart, 0, 0, 0, 0, 0, gno, eth, 0),
@@ -516,7 +519,7 @@ contract('DutchExchange - stateTransitions', accounts => {
       // clearing first auction
       await postBuyOrder(eth, gno, auctionIndex, 10.0.toWei() * 3, buyer1)
 
-      const [ state ] = await Promise.all([
+      const [state] = await Promise.all([
         getState(eth, gno),
         // checkState = async (auctionIndex, auctionStart, sellVolumesCurrent, sellVolumesNext, buyVolumes, closingPriceNum, closingPriceDen, ST, BT, MaxRoundingError) => {
         checkState(2, 1, 0, 0, 0, 0, 0, eth, gno, 1),
@@ -538,7 +541,7 @@ contract('DutchExchange - stateTransitions', accounts => {
       await assertRejects(postSellOrder(eth, gno, auctionIndex, 10.0.toWei() * 3, seller1))
       await assertRejects(postSellOrder(eth, gno, auctionIndex + 2, 10.0.toWei() * 3, seller1))
 
-      const [ state ] = await Promise.all([
+      const [state] = await Promise.all([
         getState(eth, gno),
         // checkState = async (auctionIndex, auctionStart, sellVolumesCurrent, sellVolumesNext, buyVolumes, closingPriceNum, closingPriceDen, ST, BT, MaxRoundingError) => {
         checkState(1, auctionStart, valMinusFee(10.0.toWei()), valMinusFee(10.0.toWei() * 6), 0, 0, 0, eth, gno, 0),
@@ -557,7 +560,7 @@ contract('DutchExchange - stateTransitions', accounts => {
       // post buyOrder to clear auction with small overbuy
       await postBuyOrder(eth, gno, auctionIndex, (10.0.toWei()), buyer1)
 
-      const [ state ] = await Promise.all([
+      const [state] = await Promise.all([
         getState(eth, gno),
         // checkState = async (auctionIndex, auctionStart, sellVolumesCurrent, sellVolumesNext, buyVolumes, closingPriceNum, closingPriceDen, ST, BT, MaxRoundingError) => {
         checkState(1, auctionStart, valMinusFee(10.0.toWei()), 0, valMinusFee(10.0.toWei()), 0, 0, eth, gno, 0),
@@ -789,7 +792,6 @@ contract('DutchExchange - stateTransitions', accounts => {
     it('timeelapse - getting into S4', async () => {
       const auctionIndex = await getAuctionIndex()
       await setAndCheckAuctionStarted(eth, gno)
-
 
       await postBuyOrder(gno, eth, auctionIndex, (ether * 5 / 2 / 2 / 2), buyer2)
       await waitUntilPriceIsXPercentOfPreviousPrice(eth, gno, 0.1)

--- a/test/testFunctions.js
+++ b/test/testFunctions.js
@@ -83,6 +83,11 @@ const getBalance = async (acct, token) => {
   return (await dx.balances.call(token.address, acct)).toNumber()
 }
 
+const getAuctionStart = async (ST, BT) => {
+  const { DutchExchange: dx } = await getContracts()
+  return (await dx.getAuctionStart.call(ST.address, BT.address)).toNumber()
+}
+
 /**
  * >setupTest()
  * @param {Array[address]} accounts         => ganache-cli accounts passed in globally
@@ -119,6 +124,7 @@ const setupTest = async (
     dx.deposit(eth.address, startingETH, { from: acct })
     dx.deposit(gno.address, startingGNO, { from: acct })
   }))
+
   // add token Pair
   // updating the oracle Price. Needs to be changed later to another mechanism
   await oracle.post(ethUSDPrice, 1516168838 * 2, medianizer.address, { from: accounts[0] })
@@ -319,6 +325,7 @@ const postSellOrder = async (ST, BT, aucIdx, amt, acct) => {
     `)
   }
   // log('POSTBUYORDER TX RECEIPT ==', await dx.postBuyOrder(ST.address, BT.address, auctionIdx, amt, { from: acct }))
+  // console.log({ st: ST.address, bt: BT.address, auctionIdx, amt, from: acct })
   return dx.postSellOrder(ST.address, BT.address, auctionIdx, amt, { from: acct })
 }
 
@@ -711,5 +718,6 @@ module.exports = {
   wait,
   waitUntilPriceIsXPercentOfPreviousPrice,
   calculateTokensInExchange,
-  getClearingTime
+  getClearingTime,
+  getAuctionStart
 }

--- a/test/testFunctions.js
+++ b/test/testFunctions.js
@@ -1,3 +1,6 @@
+/* global, assert, artifacts */
+/* eslint no-undef: "error" */
+
 /*
   eslint prefer-const: 0,
   max-len: 0,
@@ -23,10 +26,10 @@ const {
 // add wei converter
 /* eslint no-extend-native: 0 */
 
-Number.prototype.toWei = function toWei() {
+Number.prototype.toWei = function toWei () {
   return bn(this, 10).times(10 ** 18).toNumber()
 }
-Number.prototype.toEth = function toEth() {
+Number.prototype.toEth = function toEth () {
   return bn(this, 10).div(10 ** 18).toNumber()
 }
 
@@ -42,7 +45,7 @@ const contractNames = [
   'TokenFRTProxy',
   'PriceOracleInterface',
   'PriceFeed',
-  'Medianizer',
+  'Medianizer'
 ]
 // DutchExchange and TokenOWL are added after their respective Proxy contracts are deployed
 
@@ -93,16 +96,16 @@ const setupTest = async (
     EtherToken: eth,
     TokenGNO: gno,
     PriceFeed: oracle,
-    Medianizer: medianizer,
+    Medianizer: medianizer
   },
   {
     startingETH = 50.0.toWei(),
     startingGNO = 50.0.toWei(),
-    ethUSDPrice = 1100.0.toWei(),
+    ethUSDPrice = 1100.0.toWei()
   }) => {
   // Await ALL Promises for each account setup
 
-  await Promise.all(accounts.map((acct) => {
+  await Promise.all(accounts.map(acct => {
     /* eslint array-callback-return:0 */
     if (acct === accounts[0]) return
     eth.deposit({ from: acct, value: startingETH })
@@ -111,7 +114,7 @@ const setupTest = async (
     gno.approve(dx.address, startingGNO, { from: acct })
   }))
   // Deposit depends on ABOVE finishing first... so run here
-  await Promise.all(accounts.map((acct) => {
+  await Promise.all(accounts.map(acct => {
     if (acct === accounts[0]) return
     dx.deposit(eth.address, startingETH, { from: acct })
     dx.deposit(gno.address, startingGNO, { from: acct })
@@ -160,7 +163,7 @@ const setAndCheckAuctionStarted = async (ST, BT) => {
  */
 const waitUntilPriceIsXPercentOfPreviousPrice = async (ST, BT, p) => {
   const { DutchExchange: dx } = await getContracts()
-  const [ getAuctionIndex, getAuctionStart ] = await Promise.all([
+  const [getAuctionIndex, getAuctionStart] = await Promise.all([
     dx.getAuctionIndex.call(ST.address, BT.address),
     dx.getAuctionStart.call(ST.address, BT.address)
   ])
@@ -183,7 +186,7 @@ const waitUntilPriceIsXPercentOfPreviousPrice = async (ST, BT, p) => {
 
   const timeToWaitFor = Math.ceil((86400 - p * 43200) / (1 + p)) + startingTimeOfAuction
   // wait until the price is good
-  await wait(timeToWaitFor - timestamp());
+  await wait(timeToWaitFor - timestamp())
 
   if (!silent) {
     ([num, den] = (await dx.getCurrentAuctionPrice.call(ST.address, BT.address, currentIndex)))
@@ -369,7 +372,7 @@ const claimSellerFunds = async (ST, BT, user, aucIdx, acct) => {
    */
 const assertClaimingFundsCreatesMGNs = async (ST, BT, acc, type) => {
   const {
-    DutchExchange: dx, TokenFRT: tokenMGN,
+    DutchExchange: dx, TokenFRT: tokenMGN
   } = await getContracts()
 
   if (!ST || !BT) throw new Error('No tokens passed in')
@@ -409,7 +412,7 @@ const assertClaimingFundsCreatesMGNs = async (ST, BT, acc, type) => {
    */
 const checkUserReceivesTulipTokens = async (ST, BT, user, idx, lastClosingPrice) => {
   const {
-    DutchExchange: dx, EtherToken: eth, TokenGNO: gno, TokenFRT: tokenMGN,
+    DutchExchange: dx, EtherToken: eth, TokenGNO: gno, TokenFRT: tokenMGN
   } = await getContracts()
   ST = ST || eth; BT = BT || gno
   const aucIdx = idx || await getAuctionIndex(ST, BT)
@@ -534,20 +537,20 @@ const assertReturnedPlusMGNs = async (ST, BT, acc, type, idx = 1, eth) => {
       } else {
         assert.equal(tulipsIssued, returned)
       }
-    // else this is a ERC20:ERC20 trade
+      // else this is a ERC20:ERC20 trade
     } else {
       assert.equal(tulipsIssued, userBalances * hNum / hDen)
     }
     // all claimSellFunds calc returned the same
     assert.equal(returned, userBalances * (num / den))
-  // Buyer
+    // Buyer
   } else if (!nonETH) {
     if (BTName === 'Ether Token') {
       assert.equal(tulipsIssued, userBalances, 'claimBuyerFunds: BT = ETH >--> tulips = buyerBalances')
     } else {
       assert.isAtLeast(userBalances * (den / num), tulipsIssued, 'claimBuyerFunds: ST = ETH >--> tulips = buyerBalances * (den/num)')
     }
-  // Trade involves ERC20:ERC20 pair
+    // Trade involves ERC20:ERC20 pair
   } else {
     assert.equal(tulipsIssued, userBalances * (hNum / hDen), 'claimBuyerFunds: ERC20:ERC20 tulips = buyerBalances * (hNum/hDen)')
   }
@@ -708,5 +711,5 @@ module.exports = {
   wait,
   waitUntilPriceIsXPercentOfPreviousPrice,
   calculateTokensInExchange,
-  getClearingTime,
+  getClearingTime
 }


### PR DESCRIPTION
This branch adds the missing test for ensuring the logic on how to start an auction.
It adds 8 tests, detailed at the end of this post.

**IMPORTANT**: 
* In order to allow someone to poke the contract after 24h to ensure the specs from for tests 5 and 6, I had to relax a constraint in the smart contract, so now it allows to submit a sell order with an amount of 0 (similar to what is done in the buy function)
* Important changes are in `DutchExchange.sol` and `test/dutchExchange-startAuctionTheshold.spec.js`, the other changes were done to remove some lint errors.

**test/dutchExchange-startAuctionTheshold.spec.js**
1. doesn't start the auction when sellVolume is below the threshold in both sides
2. does't start if we surplus one of the sides
3. does't start if we surplus the opposite side
4. starts if we surplus both sides
5. starts if there is enough funding in one side and 24h goes by
6. starts if there is enough funding in the opposite side and 24h goes by
7. starts if after 24h, someone surplus one side
8. starts if after 24h, someone surplus the opposite side