### PR TITLE
Fix for dx-daostack migrations

### DIFF
--- a/src/migrations-truffle-4/4_deploy_FRT.js
+++ b/src/migrations-truffle-4/4_deploy_FRT.js
@@ -23,7 +23,7 @@ function migrate ({
 function _getDependencies (artifacts, network, deployer) {
   let Math
   if (network === 'development') {
-    Math = artifacts.require('Math')
+    Math = artifacts.require('GnosisMath')
   } else {
     const contract = require('truffle-contract')
     Math = contract(require('@gnosis.pm/util-contracts/build/contracts/Math'))

--- a/src/migrations-truffle-5/2_migrate_dependencies.js
+++ b/src/migrations-truffle-5/2_migrate_dependencies.js
@@ -1,7 +1,7 @@
 // TODO: Provide a index.js that migrate all in utils, GNO and OWL
-const deployUtils = require('@gnosis.pm/util-contracts/src/migrations-truffle-4')
-const deployGno = require('@gnosis.pm/gno-token/src/migrations-truffle-4')
-const deployOwl = require('@gnosis.pm/owl-token/src/migrations-truffle-4')
+const deployUtils = require('@gnosis.pm/util-contracts/src/migrations-truffle-5')
+const deployGno = require('@gnosis.pm/gno-token/src/migrations-truffle-5')
+const deployOwl = require('@gnosis.pm/owl-token/src/migrations-truffle-5')
 
 async function migrate({
   artifacts,

--- a/src/migrations-truffle-5/4_deploy_FRT.js
+++ b/src/migrations-truffle-5/4_deploy_FRT.js
@@ -21,7 +21,7 @@ async function migrate ({
 function _getDependencies (artifacts, network, deployer) {
   let Math
   if (network === 'development') {
-    Math = artifacts.require('Math')
+    Math = artifacts.require('GnosisMath')
   } else {
     const contract = require('truffle-contract')
     Math = contract(require('@gnosis.pm/util-contracts/build/contracts/Math'))

--- a/src/migrations-truffle-5/EXAMPLE_migrate_all.js
+++ b/src/migrations-truffle-5/EXAMPLE_migrate_all.js
@@ -1,11 +1,11 @@
 /* global artifacts, web3 */
 /* eslint no-undef: "error" */
 
-const deployUtils = require('@gnosis.pm/util-contracts/src/migrations-truffle-4')
-const deployGno = require('@gnosis.pm/gno-token/src/migrations-truffle-4')
-const deployOwl = require('@gnosis.pm/owl-token/src/migrations-truffle-4')
+const deployUtils = require('@gnosis.pm/util-contracts/src/migrations-truffle-5')
+const deployGno = require('@gnosis.pm/gno-token/src/migrations-truffle-5')
+const deployOwl = require('@gnosis.pm/owl-token/src/migrations-truffle-5')
 
-const migrationsDx = require('@gnosis.pm/dx-contracts/src/migrations-truffle-4')
+const migrationsDx = require('@gnosis.pm/dx-contracts/src/migrations-truffle-5')
 
 module.exports = async (deployer, network, accounts) => {
   if (network === 'development') {


### PR DESCRIPTION
Renames Math library to avoid name collisions
Required for [dx-daostack#41](https://github.com/gnosis/dx-daostack/pull/41)