### PR TITLE
Update add-token-pair to use list or individual token pair

### DIFF
--- a/src/truffle/add-token-pairs.js
+++ b/src/truffle/add-token-pairs.js
@@ -61,7 +61,7 @@ async function addTokenPairs () {
     User account: ${contractsInfo.account}
     DX address: ${contractsInfo.dx.address}
     WETH address: ${contractsInfo.wethAddress}
-    Ether balance: ${contractsInfo.etherBalance}    
+    Ether balance: ${contractsInfo.etherBalance}
     Threshold: $${contractsInfo.thresholdInUSD.toFixed(2)}
     Current Ether price: ${contractsInfo.etherPrice}
 `)
@@ -72,10 +72,15 @@ async function addTokenPairs () {
       gasPrice,
       dryRun
     }
-    console.log(`Adding ${tokenPairs.length} token pairs`)
-    for (let i = 0; i < tokenPairs.length; i++) {
-      // Add token (syncronously)
-      await addTokenPair(tokenPairs[i], contractsInfo, params)
+    if (Array.isArray(tokenPairs)) {
+      console.log(`Adding ${tokenPairs.length} token pairs`)
+      for (let i = 0; i < tokenPairs.length; i++) {
+        // Add token (syncronously)
+        await addTokenPair(tokenPairs[i], contractsInfo, params)
+      }
+    } else {
+      console.log(`Adding 1 token pair`)
+      await addTokenPair(tokenPairs, contractsInfo, params)
     }
     console.log('\n **************  End of add token pairs  **************\n')
   }


### PR DESCRIPTION
Update add-token-pair script to be able to use just the JSON for 1 token pair

This way we can shortcut the add-token-pair in dx-docs to create 1 file and simplify the execution