### PR TITLE
Dx Dao whitelist review

### DIFF
--- a/test/resources/approve-tokens/dxDAO_approved_tokens.js
+++ b/test/resources/approve-tokens/dxDAO_approved_tokens.js
@@ -1,3 +1,7 @@
+// WARNING: We recommend and it is your own responsibility to check that the token is
+// ERC20 compliant and hence compatible with the DutchX protocol before adding
+// tokens to the protocol layer
+
 module.exports = [
   {
     'name': 'Wrapped Ether',

--- a/test/resources/approve-tokens/dxDAO_approved_tokens.js
+++ b/test/resources/approve-tokens/dxDAO_approved_tokens.js
@@ -175,13 +175,6 @@ module.exports = [
     'etherScanLink': 'https://etherscan.io/token/0x960b236A07cf122663c4303350609A66A7B288C0'
   },
   {
-    'name': 'Aurora',
-    'symbol': 'AURA',
-    'address': '0xcdcfc0f66c522fd086a1b725ea3c0eeb9f9e8814',
-    'approve': true,
-    'etherScanLink': 'https://etherscan.io/token/0xcdcfc0f66c522fd086a1b725ea3c0eeb9f9e8814'
-  },
-  {
     'name': 'Bluzelle',
     'symbol': 'BLZ',
     'address': '0x5732046a883704404f284ce41ffadd5b007fd668',
@@ -238,11 +231,18 @@ module.exports = [
     'etherScanLink': 'https://etherscan.io/token/0x12b19d3e2ccc14da04fae33e63652ce469b3f2fd'
   },
   {
+    'name': 'IDEX Token',
+    'symbol': 'IDEX',
+    'address': '0xB705268213D593B8FD88d3FDEFF93AFF5CbDcfAE',
+    'approve': true,
+    'etherScanLink': 'https://etherscan.io/token/0xB705268213D593B8FD88d3FDEFF93AFF5CbDcfAE'
+  },
+  {
     'name': 'Loopring',
     'symbol': 'LRC',
-    'address': '0xef68e7c694f40c8202821edf525de3782458639f',
+    'address': '0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD',
     'approve': true,
-    'etherScanLink': 'https://etherscan.io/token/0xef68e7c694f40c8202821edf525de3782458639f'
+    'etherScanLink': 'https://etherscan.io/token/0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD'
   },
   {
     'name': 'OST',

--- a/test/resources/approve-tokens/dxDAO_approved_tokens.js
+++ b/test/resources/approve-tokens/dxDAO_approved_tokens.js
@@ -63,13 +63,6 @@ module.exports = [
     'address': '0x6810e776880c02933d47db1b9fc05908e5386b96'
   },
   {
-    'name': 'Golem',
-    'symbol': 'GNT',
-    'approve': true,
-    'etherScanLink': 'https://etherscan.io/token/0xa74476443119A942dE498590Fe1f2454d7D4aC0d',
-    'address': '0xa74476443119A942dE498590Fe1f2454d7D4aC0d'
-  },
-  {
     'name': 'KyberNetwork',
     'symbol': 'KNC',
     'approve': true,


### PR DESCRIPTION
After revieweing again the whitelist we found that Golem Token is not compatible with DutchX.

Also we detected that Loopring updated their token address recently and AURA token is currently being migrated to IDEX token