### PR TITLE
Add Streamr DATA to potential whitelist

### DIFF
--- a/test/resources/approve-tokens/dxDAO_approved_tokens.js
+++ b/test/resources/approve-tokens/dxDAO_approved_tokens.js
@@ -289,5 +289,12 @@ module.exports = [
     'address': '0x985dd3d42de1e256d09e1c10f112bccb8015ad41',
     'approve': true,
     'etherScanLink': 'https://etherscan.io/token/0x985dd3d42de1e256d09e1c10f112bccb8015ad41'
+  },
+  {
+    'name': 'Streamr',
+    'symbol': 'DATA',
+    'address': '0x0cf0ee63788a0849fe5297f3407f701e122cc023',
+    'approve': true,
+    'etherScanLink': 'https://etherscan.io/token/0x0cf0ee63788a0849fe5297f3407f701e122cc023'
   }
 ]


### PR DESCRIPTION
Suggesting addition of Streamr (DATA) to the suggested whitelist in order to encourage the Streamr community to add it to the DutchX protocol. 

[This blog post](https://blog.gnosis.pm/dutchx-token-listing-reward-ece1036d1099) gives the impression that only tokens on this list can be added to DutchX (in the section "What exactly do I have to do?"). 

While my understanding is that tokens can actually be freely added via the smart contract - regardless of this list - I'm still proposing DATA to be added to the list in order to allow DATA traders to earn Magnolia for trading it after it gets added to DutchX.